### PR TITLE
fixe deprecated formattedCodeWithMaxLineLength: by using formattedCode

### DIFF
--- a/src/Roassal2GT/RTExampleSelection.class.st
+++ b/src/Roassal2GT/RTExampleSelection.class.st
@@ -132,7 +132,7 @@ RTExampleSelection >> matchesQuery: aSetOfNames [
 { #category : #public }
 RTExampleSelection >> playgroundSourceCode [ 
 	" this is really ugly - we would like to perfectly preserve the original format including comments BUT with pragmas stripped - is there a better way ? original code below "
-	^ self method parseTree body formattedCodeWithMaxLineLength: 999
+	^ self method parseTree body formattedCode
 	"
 	| sourceCode firstLine sourceCodeWithoutFirstLine |
 	sourceCode := self method sourceCode.


### PR DESCRIPTION
Since Pharo 70.
We cannot use the selector #formattedCodeWithMaxLineLength:

I think, we can use #formattedCode since it does work in Pharo 60 and 70.