### PR TITLE
fix example 22

### DIFF
--- a/src/Roassal2/RTGrapherExample.class.st
+++ b/src/Roassal2/RTGrapherExample.class.st
@@ -1186,7 +1186,7 @@ CF8IH74QvhA+fCF8+EL4QvjwhfCF8OEL4QvhwxdC5g9sF+trm6wBMAAAAABJRU5ErkJggg=='
 RTGrapherExample >> examplePopulationUSA [
 <noTest>
 | b  tab |
-tab := RTTabTable new input: (TRPlatform current download: 'https://www.census.gov/popest/data/state/asrh/2013/files/SCPRC-EST2013-18+POP-RES.csv') contents usingDelimiter: $,.
+tab := RTTabTable new input: (TRPlatform current download: 'https://www2.census.gov/programs-surveys/popest/datasets/2010-2013/state/asrh/scprc-est2013-18+pop-res.csv') contents usingDelimiter: $,.
 tab removeFirstRow.
 tab convertColumnsAsInteger: #('POPESTIMATE2013' 'POPEST18PLUS2013').
 


### PR DESCRIPTION
The 22nd example in "Grapher - Overall" is broken.
The csv source file has been move there : https://www2.census.gov/programs-surveys/popest/datasets/2010-2013/state/asrh/scprc-est2013-18+pop-res.csv


https://github.com/moosetechnology/Moose/pull/1495/commits/bd0cfb675a9887739cd7f4d84ba498949de4b703
https://github.com/moosetechnology/Moose/issues/1425