### PR TITLE
The test fails if the user uses a dark theme

### DIFF
--- a/src/Roassal2-Exporter-Tests/RTSVGExporterTest.class.st
+++ b/src/Roassal2-Exporter-Tests/RTSVGExporterTest.class.st
@@ -23,6 +23,8 @@ RTSVGExporterTest >> testEmpty [
 	
 	| v str |
 	v := RTView new.
+	"use a White theme for the test"
+	v canvas theme: TRWhiteSolarizedTheme new.
 
 	str := WriteStream on: String new.
 	RTSVGExporter new view: v; exportOnStream: str.


### PR DESCRIPTION
The test fails if the user uses a dark theme.
The default background with a black theme for the canvas is "64,64,64" and no "256,256,256"