### PR TITLE
Fix bad message send to UITheme builder

### DIFF
--- a/src/Roassal2GT/GLMAbstractExportingAction.class.st
+++ b/src/Roassal2GT/GLMAbstractExportingAction.class.st
@@ -19,9 +19,10 @@ GLMAbstractExportingAction >> doExportToFull: fileName [
 GLMAbstractExportingAction >> execute [
 	| fileName |
 	fileName := UITheme builder 
-						fileSave: 'Enter the ', self titleExtension,' file name'
+						chooseForSaveFileReference: 'Enter the ', self titleExtension, ' file name'
 						extensions: self extensions
-						path: nil.
+						path: FileLocator home asPath. 
+
 	fileName notNil ifTrue: [ 
 		self doExportToFull: fileName asAbsolute ]
 ]


### PR DESCRIPTION
In Pharo 8, ComposableMorph doesn't respond to #fileSave:extensions:path:
Also need to provide a non-nil path; the user's home directory seems reasonable.