### PR TITLE
Optimizations, SVG export fixes, concurrent Roassal 3 fix

### DIFF
--- a/src/Roassal2-Core/RTAbstractElementHandling.class.st
+++ b/src/Roassal2-Core/RTAbstractElementHandling.class.st
@@ -15,7 +15,7 @@ RTAbstractElementHandling >> elements [
 
 { #category : #accessing }
 RTAbstractElementHandling >> elements: someElements [
-	elements := someElements asGroup
+	elements := someElements asRTGroup
 ]
 
 { #category : #accessing }

--- a/src/Roassal2-Core/RTAbstractGraphLayout.class.st
+++ b/src/Roassal2-Core/RTAbstractGraphLayout.class.st
@@ -254,14 +254,14 @@ RTAbstractGraphLayout >> on: el edges: edgs [
 
 { #category : #private }
 RTAbstractGraphLayout >> parentsFor: aNode [
-	^ self cachedParents
-		at: aNode
-		ifAbsentPut:
-			[ | nodes |
-			nodes := OrderedCollection new.
-			self edgesDo:
-					[:edge | edge to == aNode ifTrue: [ nodes add: edge from ] ].
-			nodes ]
+
+	^ self cachedParents at: aNode ifAbsentPut: [ 
+		  | nodes |
+		  nodes := OrderedCollection new.
+		  self edgesDo: [ :edge | 
+			  (edge to == aNode and: [ edge from ~= aNode ]) ifTrue: [ 
+				  nodes add: edge from ] ].
+		  nodes ]
 ]
 
 { #category : #private }

--- a/src/Roassal2-Core/RTAbstractRegularTreeLayout.class.st
+++ b/src/Roassal2-Core/RTAbstractRegularTreeLayout.class.st
@@ -81,7 +81,7 @@ RTAbstractRegularTreeLayout >> horizontallyReverse: elements [
 	"Horizontally reverse the elements, as well as the attachpoints"
 
 	| g largeur |
-	g := elements asGroup.
+	g := elements asRTGroup.
 	largeur := g extent x.
 	elements
 		do: [ :el | el translateTo: (largeur - el position x) @ el position y ]
@@ -191,7 +191,7 @@ RTAbstractRegularTreeLayout >> verticallyReverse: elements [
 	"Vertically reverse the elements, as well as the attachpoints"
 
 	| g hauteur |
-	g := elements asGroup.
+	g := elements asRTGroup.
 	hauteur := g extent y.
 	elements
 		do: [ :el | el translateTo: el position x @ (hauteur - el position y) ]

--- a/src/Roassal2-Core/RTAnchorConstraint.class.st
+++ b/src/Roassal2-Core/RTAnchorConstraint.class.st
@@ -1,5 +1,5 @@
 "
-I attach a RTElement to a RTEdge (works for both line and connection shapes). When the edge or it's extremities are moved, so is the anchor.
+I attach a RTElement to a RTEdge. When the edge or it's extremities are moved, so is the anchor.
 
 Furthermore I will try to move the Element in such a way that it doesn't overlap neither the edge, nor it's extremities, nor their other lines. I will not however prevent overlapping of another elements (e.g. another element or edge nearby).
 
@@ -37,15 +37,13 @@ Class {
 
 { #category : #building }
 RTAnchorConstraint >> addAnchor [
+
 	anchorElement := self anchorShape element.
 	element view add: anchorElement.
 	guideEdge := self guideLine edgeFrom: element to: anchorElement.
 	element view add: guideEdge.
-	edge trachelShape
-		addCallback:
-			(TRRemoveCallback
-				block: [ element remove.
-					anchorElement remove ])
+	edge trachelShape addCallback:
+		(TRRemoveCallback block: [ self remove ])
 ]
 
 { #category : #building }
@@ -70,26 +68,18 @@ RTAnchorConstraint >> balance: aNumber [
 
 { #category : #building }
 RTAnchorConstraint >> build [
+
 	self addAnchor.
 	edge from addCallback: (TRTranslationCallback block: [ self update ]).
 	edge to addCallback: (TRTranslationCallback block: [ self update ]).
-	"Do a symbol-based check, because DCRTConnection is not (yet?) in Roassal"
-	edge shape className asSymbol = #DCRTConnection
-		| (edge shape className asSymbol = #DCRTStyledConnection)
-		ifTrue: [ edge when: #DCRTHandleMoved asClass do: [ self update ] ].
-	element
-		when: TRMouseDragStart
-		do: [ 
-			guideLine color: Color gray.
-			guideEdge update.
-			guideEdge view signalUpdate ].
-	element
-		when: TRMouseDragEnd
-		do:
-			[ 
-			guideLine color: Color transparent.
-			guideEdge update.
-			guideEdge view signalUpdate ]
+	element when: TRMouseDragStart do: [ 
+		guideLine color: Color gray.
+		guideEdge update.
+		guideEdge view signalUpdate ].
+	element when: TRMouseDragEnd do: [ 
+		guideLine color: Color transparent.
+		guideEdge update.
+		guideEdge view signalUpdate ]
 ]
 
 { #category : #'as yet unclassified' }
@@ -108,6 +98,7 @@ RTAnchorConstraint >> computeExtraDistance [
 				           (each
 					            nearestPointAlongLineFrom: segment from
 					            to: segment to) ].
+	normals ifEmpty: [ ^ 0 ].
 	^ minDistance sign > 0
 		  ifTrue: [ normals max ]
 		  ifFalse: [ normals max negated ]
@@ -146,7 +137,9 @@ RTAnchorConstraint >> guideLine [
 
 { #category : #initialization }
 RTAnchorConstraint >> initialize [
-	(anchorShape := RTEllipse new)
+
+	super initialize.
+	(anchorShape := RTBox new)
 		size: 0;
 		color: Color red.
 	(guideLine := RTLine new) color: Color transparent
@@ -174,32 +167,24 @@ RTAnchorConstraint >> moveAnchor [
 
 { #category : #'as yet unclassified' }
 RTAnchorConstraint >> moveAwayFrom: aRectangle via: aVector [
+
 	"There should be minDistance between the start and the element. Move it in the direction fo the current segment"
 
 	| vector corners segment |
 	"source and target of the edge on top of each other... ignore"
-	aVector r = 0
-		ifTrue: [ ^ self ].
-	vector := aVector normalized * (aRectangle origin dist: aRectangle corner).
-	corners := element encompassingRectangle corners
-		select: [ :each | aRectangle containsPoint: each ].
-	segment := (corners
-		collect:
-			[ :each | 
-			| sg |
-			sg := RTLineSegment from: each to: each + vector.
-			RTLineSegment from: each to: (sg intersectRectangle: aRectangle) anyOne ])
-		detectMax: #length.
+	aVector r = 0 ifTrue: [ ^ self ].
+	vector := aVector normalized
+	          * (aRectangle origin distanceTo: aRectangle corner).
+	corners := element encompassingRectangle corners select: [ :each | 
+		           aRectangle containsPoint: each ].
+	segment := (corners collect: [ :each | 
+		            | sg |
+		            sg := RTLineSegment from: each to: each + vector.
+		            RTLineSegment
+			            from: each
+			            to: (sg intersectRectangle: aRectangle) anyOne ]) 
+		           detectMax: #length.
 	segment ifNotNil: [ element translateBy: segment vector ]
-	"	segment
-		ifNotNil:
-			[ element view
-				add:
-					(RTSVGPath new
-						path:
-							'M' , segment from x asString , ',' , segment from y asString , 'L' , segment to x asString
-								, ',' , segment to y asString;
-						element) ]"
 ]
 
 { #category : #'as yet unclassified' }
@@ -228,12 +213,19 @@ RTAnchorConstraint >> moveElement [
 		ifTrue: [ self moveAwayFrom: to via: segment vector negated ]
 ]
 
+{ #category : #building }
+RTAnchorConstraint >> remove [
+
+	element view ifNotNil: [ element remove ].
+	anchorElement view ifNotNil: [ anchorElement remove ].
+	guideEdge view ifNotNil: [ guideEdge remove ]
+]
+
 { #category : #accessing }
 RTAnchorConstraint >> segments [
-	(edge shape className = #DCRTConnection)
-		ifTrue: [ ^ RTPolyLineSegment withAll: (self connectionSegmentsFor: edge) ].
-	(edge shape isKindOf: RTBezierLine)
-		ifTrue: [ ^ self notYetImplemented ].
+
+	(edge shape isKindOf: RTBezierLine) ifTrue: [ 
+		^ self notYetImplemented ].
 	^ RTPolyLineSegment with: (self lineSegmentFor: edge)
 ]
 

--- a/src/Roassal2-Core/RTConstraint.class.st
+++ b/src/Roassal2-Core/RTConstraint.class.st
@@ -255,11 +255,21 @@ RTConstraint >> setChild: aChildShape parent: aParentShape [
 
 { #category : #'public - executing' }
 RTConstraint >> stick [
-	| block |
+
+	| block removalBlock translationCallback extentCallback |
 	self move.
 	block := [ :shape :step | self move ].
-	fixedElement addCallback: (TRTranslationCallback block: block).
-	fixedElement addCallback: (TRExtentCallback block: block)
+	removalBlock := [ :callback | 
+	                fixedElement trachelShape
+		                removeCallback: callback
+		                ifAbsent: [  ] ].
+	translationCallback := TRTranslationCallback block: block.
+	extentCallback := TRExtentCallback block: block.
+	fixedElement addCallback: translationCallback.
+	fixedElement addCallback: extentCallback.
+	movableElement addCallback: (TRRemoveCallback block: [ 
+			 removalBlock value: translationCallback.
+			 removalBlock value: extentCallback ])
 ]
 
 { #category : #'public - positioning' }

--- a/src/Roassal2-Core/RTGroup.class.st
+++ b/src/Roassal2-Core/RTGroup.class.st
@@ -39,6 +39,12 @@ RTGroup >> addAll: elements [
 	^ super addAll: elements
 ]
 
+{ #category : #adding }
+RTGroup >> addCallback: aCallback [
+
+	self elements do: [ :each | each addCallback: aCallback ]
+]
+
 { #category : #public }
 RTGroup >> addShape: aShape [
 	self do: [ :e | e addShape: aShape ]

--- a/src/Roassal2-Core/RTGroup.class.st
+++ b/src/Roassal2-Core/RTGroup.class.st
@@ -24,7 +24,8 @@ RTGroup >> @ interaction [
 
 { #category : #visitor }
 RTGroup >> accept: aRTVisitor [
-	self  do: [ :e | e trachelShape accept: aRTVisitor]
+
+	aRTVisitor visitGroup: self
 ]
 
 { #category : #accessing }
@@ -57,11 +58,18 @@ RTGroup >> addedIn: view [
 
 { #category : #converting }
 RTGroup >> asGroup [
-	^ self
+
+	self
+		deprecated: 'Use #asRTGroup for Roassal3/Pharo9+ compatibility'
+		on: '2022-03-18'
+		in: #Pharo9
+		transformWith: '`@receiver asGroup' -> '`@receiver asRTGroup'.
+	^ self asRTGroup
 ]
 
 { #category : #converting }
 RTGroup >> asRTGroup [
+
 	^ self
 ]
 

--- a/src/Roassal2-Core/RTGroupLayout.class.st
+++ b/src/Roassal2-Core/RTGroupLayout.class.st
@@ -92,7 +92,7 @@ RTGroupLayout >> getGroupsFrom: elements [
 		| els |
 		els := iterativeGroup first withAllConnectedElements.
 		els size > 1 
-			ifTrue: [ groups add: els asGroup ] 
+			ifTrue: [ groups add: els asRTGroup ] 
 			ifFalse: [ lonelyGroup addAll: els ].
 		iterativeGroup removeAll: els.
 	].

--- a/src/Roassal2-Core/RTLayoutBuilder.class.st
+++ b/src/Roassal2-Core/RTLayoutBuilder.class.st
@@ -309,7 +309,7 @@ RTLayoutBuilder >> processPartitions: elements [
 		"tupple = { conditionblock . layout }"
 		els := elements select: [ :el | tupple first rtValue: el model ].
 		tupple second on: els.
-		groupOfElements add: els asGroup.
+		groupOfElements add: els asRTGroup.
 		 ].
 	
 	layout on: groupOfElements

--- a/src/Roassal2-Core/RTNest.class.st
+++ b/src/Roassal2-Core/RTNest.class.st
@@ -64,7 +64,7 @@ RTNest >> centerOnTrachelShape: trachelShape elements: elements [
 		- translate all the elements on top of backElement
 		- perform a layout if one is set"
 
-	behavior centerOnTrachelShape: trachelShape elements: elements asGroup.
+	behavior centerOnTrachelShape: trachelShape elements: elements asRTGroup.
 
 ]
 
@@ -75,7 +75,7 @@ RTNest >> doLayoutIfNecessaryOn: elements [
 
 { #category : #utility }
 RTNest >> encompassingRectangleOf: elements [
-	^ elements asGroup encompassingRectangle 
+	^ elements asRTGroup encompassingRectangle 
 
 ]
 
@@ -233,7 +233,7 @@ RTNest >> on: element inShape: aSymbol nest: elements layout: aSymbolLayout [
 	self doLayoutIfNecessaryOn: elements.
 	
 	"We assume that the roassal shape of element is composed"
-	behavior on: (aSymbol rtValue: element trachelShape shapes) setNested: elements asGroup.
+	behavior on: (aSymbol rtValue: element trachelShape shapes) setNested: elements asRTGroup.
 	"self onTrachelShape: (aSymbol rtValue: element trachelShape shapes) nest: elements."
 
 	aSymbolLayout rtValue: element trachelShape.
@@ -292,7 +292,7 @@ RTNest >> on: backElement nestRootOf: elements [
 
 { #category : #public }
 RTNest >> on: backElement simplyNest: elements [
-	behavior on: backElement setNested: elements asGroup
+	behavior on: backElement setNested: elements asRTGroup
 ]
 
 { #category : #'OBSOLETE - to be removed' }
@@ -324,7 +324,7 @@ RTNest >> onTrachelShape: trachelShape nest: elements [
 	 - make the inner elements draggable"
 
 	self doLayoutIfNecessaryOn: elements.
-	behavior on: trachelShape setNested: elements asGroup
+	behavior on: trachelShape setNested: elements asRTGroup
 
 	"self centerOnTrachelShape: trachelShape elements: elements.
 	self makeElements: elements draggableByTrachelShape: trachelShape."

--- a/src/Roassal2-Core/RTObject.class.st
+++ b/src/Roassal2-Core/RTObject.class.st
@@ -14,6 +14,17 @@ RTObject class >> basicNew [
 
 { #category : #converting }
 RTObject >> asGroup [
+
+	self
+		deprecated: 'Use #asRTGroup for Roassal3/Pharo9+ compatibility'
+		on: '2022-03-18'
+		in: #Pharo9
+		transformWith: '`@receiver asGroup' -> '`@receiver asRTGroup'.
+	^ self asRTGroup
+]
+
+{ #category : #converting }
+RTObject >> asRTGroup [
 	^ RTGroup with: self
 
 ]

--- a/src/Roassal2-Core/RTVisitor.class.st
+++ b/src/Roassal2-Core/RTVisitor.class.st
@@ -52,6 +52,13 @@ RTVisitor >> visitCanvas: aCanvas [
 ]
 
 { #category : #visitor }
+RTVisitor >> visitGroup: aRTGroup [
+
+	aRTGroup do: [ :roassalShape | 
+		roassalShape trachelShape accept: self ]
+]
+
+{ #category : #visitor }
 RTVisitor >> visitView: aView [
 	aView canvas accept: self
 ]

--- a/src/Roassal2-Exporter-Tests/RTHTMLStringConverterTest.class.st
+++ b/src/Roassal2-Exporter-Tests/RTHTMLStringConverterTest.class.st
@@ -1,0 +1,11 @@
+Class {
+	#name : #RTHTMLStringConverterTest,
+	#superclass : #RTTest,
+	#category : #'Roassal2-Exporter-Tests'
+}
+
+{ #category : #tests }
+RTHTMLStringConverterTest >> testBasic [
+
+	self assert: (RTHTMLStringConverter new convertString: 'Hello world') equals: 'Hello&#160;world' 
+]

--- a/src/Roassal2-Exporter-Tests/RTSVGStringConverterTest.class.st
+++ b/src/Roassal2-Exporter-Tests/RTSVGStringConverterTest.class.st
@@ -7,5 +7,7 @@ Class {
 { #category : #tests }
 RTSVGStringConverterTest >> testBasic [
 
-	self assert: (RTSVGStringConverter new convertString: 'Hello world') equals: 'Hello&#160;world' 
+	self
+		assert: (RTSVGStringConverter new convertString: '< What''s up? >')
+		equals: '&lt; What&apos;s up? &gt;'
 ]

--- a/src/Roassal2-Exporter/RTCanvasExporter.class.st
+++ b/src/Roassal2-Exporter/RTCanvasExporter.class.st
@@ -1,10 +1,10 @@
 "
-A DCTRCanvasExporter is exporter of canvas into image
+A RTCanvasExporter is exporter of canvas into image. Note that this implementation is much less efficient than RTPNGExporter. If you need just simple PNG export without custom scaling/zoom, use RTPNGExporter.
 	
 	supported formats: png, jpg, jpeg, bmp, gif	
 	usage example:
 
-	(DCTRCanvasExporter canvas: roassalView canvas)
+	(RTCanvasExporter canvas: roassalView canvas)
 		withoutFixedShapes;
 		whole;
 		defaultScale;
@@ -31,6 +31,13 @@ Class {
 RTCanvasExporter class >> canvas: aCanvas [
 	^ self new
 		canvas: aCanvas;
+		yourself
+]
+
+{ #category : #initialization }
+RTCanvasExporter class >> view: aView [
+	^ self new
+		view: aView;
 		yourself
 ]
 
@@ -158,6 +165,12 @@ RTCanvasExporter >> scaleToMorphLimits [
 		ifTrue: [ self scale: maxWidthAndHeight / self extent x * self cameraScale ].
 	self extent y > maxWidthAndHeight
 		ifTrue: [ self scale: maxWidthAndHeight / self extent y * self cameraScale ]
+]
+
+{ #category : #settings }
+RTCanvasExporter >> view: aView [
+
+	self canvas: aView canvas
 ]
 
 { #category : #settings }

--- a/src/Roassal2-Exporter/RTHTMLStringConverter.class.st
+++ b/src/Roassal2-Exporter/RTHTMLStringConverter.class.st
@@ -1,0 +1,140 @@
+Class {
+	#name : #RTHTMLStringConverter,
+	#superclass : #RTObject,
+	#instVars : [
+		'convertions'
+	],
+	#category : #'Roassal2-Exporter-HTML5'
+}
+
+{ #category : #converting }
+RTHTMLStringConverter >> convertString: aString [
+	| array |
+	array := (1 to: aString size) collect: [ :n | convertions at: (aString at: n) ifAbsent: [ aString at: n ] ].
+	^ array inject: '' into: [ :acc :e | acc, (e asString) ].
+	
+]
+
+{ #category : #initialization }
+RTHTMLStringConverter >> initialize [
+	super initialize.
+	convertions := Dictionary new.
+	self initializeValues.
+]
+
+{ #category : #initialization }
+RTHTMLStringConverter >> initializeValues [
+	convertions 
+		at: $™ put: '&#8482;';
+		at: $\ put: '&#92;';
+		at: $€ put: '&euro;';
+		at: $  put: '&#160;';
+		at: $" put: '&quot;';
+		at: $& put: '&amp;';
+		at: $< put: '&lt;';
+		at: $> put: '&gt;';
+		at: $¡ put: '&iexcl;';
+		at: $¢ put: '&cent;';
+		at: $£ put: '&pound;';
+		at: $¤ put: '&curren;';
+		at: $¥ put: '&yen;';
+		at: $¦ put: '&brvbar;';
+		at: $§ put: '&sect;';
+		at: $¨ put: '&uml;';
+		at: $© put: '&copy;';
+		at: $ª put: '&ordf;';
+		at: $¬ put: '&not;';
+		at: $® put: '&reg;';
+		at: $¯ put: '&macr;';
+		at: $° put: '&deg;';
+		at: $± put: '&plusmn;';
+		at: $² put: '&sup2;';
+		at: $³ put: '&sup3;';
+		at: $´ put: '&acute;';
+		at: $µ put: '&micro;';
+		at: $¶ put: '&para;';
+		at: $· put: '&middot;';
+		at: $¸ put: '&cedil;';
+		at: $¹ put: '&sup1;';
+		at: $º put: '&ordm;';
+		at: $» put: '&raquo;';
+		at: $¼ put: '&frac14;';
+		at: $½ put: '&frac12;';
+		at: $¾ put: '&frac34;';
+		at: $¿ put: '&iquest;';
+		at: $À put: '&Agrave;';
+		at: $Á put: '&Aacute;';
+		at: $Â put: '&Acirc;';
+		at: $Ã put: '&Atilde;';
+		at: $Ä put: '&#196;';
+		at: $Å put: '&Aring;';
+		at: $Æ put: '&AElig;';
+		at: $Ç put: '&Ccedil;';
+		at: $È put: '&Egrave;';
+		at: $É put: '&Eacute;';
+		at: $Ê put: '&Ecirc;';
+		at: $Ë put: '&Euml;';
+		at: $Ì put: '&Igrave;';
+		at: $Í put: '&Iacute;';
+		at: $Î put: '&Icirc;';
+		at: $Ï put: '&Iuml;';
+		at: $Ð put: '&ETH;';
+		at: $Ñ put: '&Ntilde;';
+		at: $Ò put: '&Ograve;';
+		at: $Ó put: '&Oacute;';
+		at: $Ô put: '&Ocirc;';
+		at: $Õ put: '&Otilde;';
+		at: $Ö put: '&Ouml;';
+		at: $× put: '&times;';
+		at: $Ø put: '&Oslash;';
+		at: $Ù put: '&Ugrave;';
+		at: $Ú put: '&Uacute;';
+		at: $Û put: '&Ucirc;';
+		at: $Ü put: '&Uuml;';
+		at: $Ý put: '&Yacute;';
+		at: $Þ put: '&THORN;';
+		at: $ß put: '&szlig;';
+		at: $à put: '&agrave;';
+		at: $á put: '&aacute;';
+		at: $â put: '&acirc;';
+		at: $ã put: '&atilde;';
+		at: $ä put: '&#228;';
+		at: $å put: '&aring;';
+		at: $æ put: '&aelig;';
+		at: $ç put: '&ccedil;';
+		at: $è put: '&egrave;';
+		at: $é put: '&eacute;';
+		at: $ê put: '&ecirc;';
+		at: $ë put: '&euml;';
+		at: $ì put: '&igrave;';
+		at: $í put: '&iacute;';
+		at: $î put: '&icirc;';
+		at: $ï put: '&iuml;';
+		at: $ð put: '&eth;';
+		at: $ñ put: '&ntilde;';
+		at: $ò put: '&ograve;';
+		at: $ó put: '&oacute;';
+		at: $ô put: '&ocirc;';
+		at: $õ put: '&otilde;';
+		at: $ö put: '&ouml;';
+		at: $÷ put: '&divide;';
+		at: $ø put: '&oslash;';
+		at: $ù put: '&ugrave;';
+		at: $ú put: '&uacute;';
+		at: $û put: '&ucirc;';
+		at: $ü put: '&uuml;';
+		at: $ý put: '&yacute;';
+		at: $þ put: '&thorn;';
+		at: $⁰ put: '&#8304;';
+		at: $¹ put: '&#185;';
+		at: $² put: '&#178;';
+		at: $³ put: '&#179;';
+		at: $⁴ put: '&#8308;';
+		at: $⁵ put: '&#8309;';
+		at: $⁶ put: '&#8310;';
+		at: $⁷ put: '&#8311;';
+		at: $⁸ put: '&#8312;';
+		at: $⁹ put: '&#8313;';
+		
+		at: Character cr put: ''.
+]

--- a/src/Roassal2-Exporter/RTJavascriptVisitor.class.st
+++ b/src/Roassal2-Exporter/RTJavascriptVisitor.class.st
@@ -166,13 +166,6 @@ RTJavascriptVisitor >> view: aView [
 ]
 
 { #category : #visitor }
-RTJavascriptVisitor >> visitAbstractLine: anAbstractLine [
-	"anAbstractLine accept: anAbstractLine
-	"
-	"TODO"
-]
-
-{ #category : #visitor }
 RTJavascriptVisitor >> visitArcLine: aLineArc [
 
 	self notYetImplemented
@@ -207,8 +200,8 @@ RTJavascriptVisitor >> visitArcShape: aShape [
 
 ]
 
-{ #category : #visitor }
-RTJavascriptVisitor >> visitArrowHeadShape: arrowShape [
+{ #category : #'visitor-decorations' }
+RTJavascriptVisitor >> visitArrowHeadShape: arrowShape onStart: aBoolean [
 	| e |
 	e := arrowShape element.
 	stream nextPutAll: '
@@ -233,8 +226,8 @@ RTJavascriptVisitor >> visitArrowHeadShape: arrowShape [
 	
 ]
 
-{ #category : #visitor }
-RTJavascriptVisitor >> visitArrowShape: arrowShape [
+{ #category : #'visitor-decorations' }
+RTJavascriptVisitor >> visitArrowShape: arrowShape onStart: aBoolean [
 	| e |
 	e := arrowShape element.
 	stream nextPutAll: '
@@ -380,8 +373,8 @@ RTJavascriptVisitor >> visitCanvas: aCanvas [
 
 ]
 
-{ #category : #visitor }
-RTJavascriptVisitor >> visitDiamondShape: diamondShape [
+{ #category : #'visitor-decorations' }
+RTJavascriptVisitor >> visitDiamondShape: diamondShape onStart: aBoolean [
 	"TODO"
 
 ]
@@ -458,11 +451,6 @@ RTJavascriptVisitor >> visitGrid: aGridShape [
 	"do not draw a grid"
 
 	
-]
-
-{ #category : #visitor }
-RTJavascriptVisitor >> visitGroup: aRTGroup [
-	aRTGroup accept: self.
 ]
 
 { #category : #'visitor-interactions' }
@@ -753,6 +741,12 @@ RTJavascriptVisitor >> visitShowLabelInteraction: anInt with: el [
 	].
 	stream nextPutAll: ']) '.
 	anInt doUnhighlightElement: el
+]
+
+{ #category : #visiting }
+RTJavascriptVisitor >> visitTextShape: aText [
+
+	self notYetImplemented
 ]
 
 { #category : #visitor }

--- a/src/Roassal2-Exporter/RTJavascriptVisitor.class.st
+++ b/src/Roassal2-Exporter/RTJavascriptVisitor.class.st
@@ -173,6 +173,12 @@ RTJavascriptVisitor >> visitAbstractLine: anAbstractLine [
 ]
 
 { #category : #visitor }
+RTJavascriptVisitor >> visitArcLine: aLineArc [
+
+	self notYetImplemented
+]
+
+{ #category : #visitor }
 RTJavascriptVisitor >> visitArcShape: aShape [
 	aShape topLeft ifNil: [ aShape computeRectangle ].
 	stream nextPutAll: '
@@ -444,6 +450,14 @@ RTJavascriptVisitor >> visitEllipseShape: anEllipse [
 	self addColor: anEllipse color.
 	self addInteractions: anEllipse element.
 	self addMatrix: anEllipse matrix.
+]
+
+{ #category : #visitor }
+RTJavascriptVisitor >> visitGrid: aGridShape [
+
+	"do not draw a grid"
+
+	
 ]
 
 { #category : #visitor }

--- a/src/Roassal2-Exporter/RTLineDecorationInfo.class.st
+++ b/src/Roassal2-Exporter/RTLineDecorationInfo.class.st
@@ -1,0 +1,85 @@
+"
+I am a simple data class for RTSVGVisitor and contain information about what line decoration belongs to which end of which line
+"
+Class {
+	#name : #RTLineDecorationInfo,
+	#superclass : #Object,
+	#instVars : [
+		'line',
+		'decoration',
+		'startOrEnd'
+	],
+	#category : #'Roassal2-Exporter-SVG'
+}
+
+{ #category : #'as yet unclassified' }
+RTLineDecorationInfo class >> line: aTRLine decoration: aTRDecorationShape [
+
+	^ self new
+		  line: aTRLine;
+		  decoration: aTRDecorationShape;
+		  yourself
+]
+
+{ #category : #'as yet unclassified' }
+RTLineDecorationInfo class >> line: aTRLine decorationOnStart: aTRDecorationShape [
+
+	^ (self line: aTRLine decoration: aTRDecorationShape)
+		  onStart;
+		  yourself
+]
+
+{ #category : #accessing }
+RTLineDecorationInfo >> decoration [
+
+	^ decoration
+]
+
+{ #category : #accessing }
+RTLineDecorationInfo >> decoration: anObject [
+
+	decoration := anObject
+]
+
+{ #category : #initialization }
+RTLineDecorationInfo >> initialize [
+
+	super initialize.
+	self onEnd
+]
+
+{ #category : #accessing }
+RTLineDecorationInfo >> isOnStart [
+
+	^ startOrEnd = #start
+]
+
+{ #category : #accessing }
+RTLineDecorationInfo >> line [
+
+	^ line
+]
+
+{ #category : #accessing }
+RTLineDecorationInfo >> line: anObject [
+
+	line := anObject
+]
+
+{ #category : #accessing }
+RTLineDecorationInfo >> onEnd [
+
+	startOrEnd := #end
+]
+
+{ #category : #accessing }
+RTLineDecorationInfo >> onStart [
+
+	startOrEnd := #start
+]
+
+{ #category : #accessing }
+RTLineDecorationInfo >> startOrEnd [
+
+	^ startOrEnd
+]

--- a/src/Roassal2-Exporter/RTSVGAbstractLine.class.st
+++ b/src/Roassal2-Exporter/RTSVGAbstractLine.class.st
@@ -7,40 +7,61 @@ Class {
 	#name : #RTSVGAbstractLine,
 	#superclass : #RTSVGEntity,
 	#instVars : [
-		'decoration'
+		'decorationsInfo'
 	],
 	#category : #'Roassal2-Exporter-SVG'
 }
 
-{ #category : #adding }
-RTSVGAbstractLine >> addMarker: stream [
-	stream 
-		nextPutAll: 'marker-end = "url(#marker' , (self getDecorationId: self decoration) , ')" '
-]
-
-{ #category : #accessing }
-RTSVGAbstractLine >> decoration [
-	^ decoration
-]
-
-{ #category : #accessing }
-RTSVGAbstractLine >> decoration: anObject [
-	decoration := anObject
-]
-
 { #category : #utils }
-RTSVGAbstractLine >> getDecorationId: aLineDecorationShape [
-	|t w c s lw|
-	t := aLineDecorationShape class name.
-	w := aLineDecorationShape mySize.
-	c := aLineDecorationShape color.
-	s := aLineDecorationShape strokePaint.
-	lw := aLineDecorationShape width.
-	^(t asString, w asString, ((c red * 256) + (s red * 256)) rounded asString, ((c green * 256) + (s green * 256)) rounded asString, ((c blue * 256) + (s blue * 256)) rounded asString, lw asString)
-	
+RTSVGAbstractLine class >> getDecorationId: aDecorationInfo [
+
+	| t w c s lw shape sp |
+	shape := aDecorationInfo decoration.
+	t := shape class name.
+	w := shape mySize.
+	c := shape color.
+	sp := shape strokePaint.
+	lw := shape width.
+	s := aDecorationInfo startOrEnd.
+	^ t asString , w asString
+	  , (c red * 256 + (sp red * 256)) rounded asString
+	  , (c green * 256 + (sp green * 256)) rounded asString
+	  , (c blue * 256 + (sp blue * 256)) rounded asString , lw asString
+	  , s asString
+]
+
+{ #category : #adding }
+RTSVGAbstractLine >> addMarkers: stream [
+
+	self decorationsInfo do: [ :eachDecorationInfo | 
+		stream
+			nextPutAll: 'marker-';
+			nextPutAll: eachDecorationInfo startOrEnd;
+			nextPutAll: ' = "url(#marker';
+			nextPutAll: (self class getDecorationId: eachDecorationInfo);
+			nextPutAll: ')" ' ]
+]
+
+{ #category : #accessing }
+RTSVGAbstractLine >> decorationsInfo [
+
+	^ decorationsInfo
+]
+
+{ #category : #accessing }
+RTSVGAbstractLine >> decorationsInfo: anArray [
+
+	decorationsInfo := anArray
 ]
 
 { #category : #accessing }
 RTSVGAbstractLine >> id [
 	^ id
+]
+
+{ #category : #initialization }
+RTSVGAbstractLine >> initialize [
+
+	super initialize.
+	decorationsInfo := #(  )
 ]

--- a/src/Roassal2-Exporter/RTSVGAbstractMarker.class.st
+++ b/src/Roassal2-Exporter/RTSVGAbstractMarker.class.st
@@ -10,7 +10,8 @@ Class {
 	#instVars : [
 		'xExtent',
 		'yExtent',
-		'size'
+		'size',
+		'startOrEnd'
 	],
 	#category : #'Roassal2-Exporter-SVG'
 }
@@ -51,12 +52,17 @@ RTSVGAbstractMarker >> addPath: stream [
 
 { #category : #adding }
 RTSVGAbstractMarker >> addRefPosition: stream [
-	stream nextPutAll: ('refX = "<1p>" refY = "<2p>" ' expandMacrosWith: self xExtent with: (self yExtent / 2) rounded)
+
+	stream nextPutAll: ('refX = "<1p>" refY = "<2p>" '
+			 expandMacrosWith: (self xClosestToAttachPoint)
+			 with: (self yExtent / 2) rounded)
 ]
 
 { #category : #adding }
 RTSVGAbstractMarker >> addSize: stream [
-	stream nextPutAll: ('markerWidth = "<1p>" markerHeight = "<1p>" ' expandMacrosWith: size)
+
+	stream nextPutAll:
+		('markerWidth = "<1p>" markerHeight = "<1p>" ' expandMacrosWith: size)
 ]
 
 { #category : #adding }
@@ -80,10 +86,24 @@ RTSVGAbstractMarker >> id: aid fillColor: aColor borderColor: anotherColor width
 
 { #category : #initialization }
 RTSVGAbstractMarker >> initialize [
+
 	self type: 'marker'.
 	self label: 'marker'.
+	startOrEnd := #end.
 	xExtent := 10.
-	yExtent := 10.
+	yExtent := 10
+]
+
+{ #category : #testing }
+RTSVGAbstractMarker >> isOnStart [
+
+	^ startOrEnd = #start
+]
+
+{ #category : #accessing }
+RTSVGAbstractMarker >> onStart [
+
+	startOrEnd := #start
 ]
 
 { #category : #adding }
@@ -94,6 +114,14 @@ RTSVGAbstractMarker >> openInnerDef: stream [
 { #category : #accessing }
 RTSVGAbstractMarker >> size: anObject [
 	size := anObject
+]
+
+{ #category : #accessing }
+RTSVGAbstractMarker >> xClosestToAttachPoint [
+
+	^ self isOnStart
+		  ifTrue: [ 0 ]
+		  ifFalse: [ self xExtent ]
 ]
 
 { #category : #accessing }

--- a/src/Roassal2-Exporter/RTSVGArrowHeadMarker.class.st
+++ b/src/Roassal2-Exporter/RTSVGArrowHeadMarker.class.st
@@ -9,7 +9,22 @@ Class {
 }
 
 { #category : #adding }
-RTSVGArrowHeadMarker >> addPath: stream [	
-	stream
-		nextPutAll: (' d="M 0 0 L <1p> <2p> L 0 <1p> z" ' expandMacrosWith: xExtent with: ((yExtent/2) rounded)).
+RTSVGArrowHeadMarker >> addPath: stream [
+
+	"<1p> = half of width
+	 <2p> = move needed from x furthest from attach point to the x closest attach point
+	 <3p> = opposite of <2p>
+	 <4p> = x furthest from attach point"
+
+	stream nextPutAll: (' d="M <4p> 0 l <2p> <1p> l <3p> <1p> z" '
+			 expandMacrosWith: (yExtent / 2) rounded
+			 with: (self isOnStart
+					  ifTrue: [ xExtent negated ]
+					  ifFalse: [ xExtent ])
+			 with: (self isOnStart
+					  ifTrue: [ xExtent ]
+					  ifFalse: [ xExtent negated ])
+			 with: (self isOnStart
+					  ifTrue: [ xExtent ]
+					  ifFalse: [ 0 ]))
 ]

--- a/src/Roassal2-Exporter/RTSVGArrowMarker.class.st
+++ b/src/Roassal2-Exporter/RTSVGArrowMarker.class.st
@@ -10,6 +10,21 @@ Class {
 
 { #category : #adding }
 RTSVGArrowMarker >> addPath: stream [	
-	stream
-		nextPutAll: (' d="M 0 0 L <1p> <2p> L 0 <1p>" ' expandMacrosWith: xExtent with: ((yExtent/2) rounded)).
+
+	"<1p> = half of width
+	 <2p> = move needed from x furthest from attach point to the x closest attach point
+	 <3p> = opposite of <2p>
+	 <4p> = x furthest from attach point"
+
+	stream nextPutAll: (' d="M <4p> 0 l <2p> <1p> l <3p> <1p> l <2p> -<1p>" '
+			 expandMacrosWith: (yExtent / 2) rounded
+			 with: (self isOnStart
+					  ifTrue: [ xExtent negated ]
+					  ifFalse: [ xExtent ])
+			 with: (self isOnStart
+					  ifTrue: [ xExtent ]
+					  ifFalse: [ xExtent negated ])
+			 with: (self isOnStart
+					  ifTrue: [ xExtent ]
+					  ifFalse: [ 0 ]))
 ]

--- a/src/Roassal2-Exporter/RTSVGBezierLine.class.st
+++ b/src/Roassal2-Exporter/RTSVGBezierLine.class.st
@@ -47,6 +47,7 @@ RTSVGBezierLine >> addCurves: stream with: visitor [
 
 { #category : #adding }
 RTSVGBezierLine >> addOn: stream using: aSVGVisitor [
+
 	| from to shape el |
 	shape := self element.
 	el := shape element.
@@ -61,11 +62,11 @@ RTSVGBezierLine >> addOn: stream using: aSVGVisitor [
 	self addStrokeOpacity: stream.
 	self addStrokeWidth: stream.
 	self closeTag: stream.
-	self decoration ifNotNil: [ self addMarker: stream ].
+	self addMarkers: stream.
 	self startClass: stream.
 	self closeTag: stream.
 	self addExternalInteractions: aSVGVisitor.
-	self closeDef: stream.
+	self closeDef: stream
 ]
 
 { #category : #adding }
@@ -83,13 +84,20 @@ RTSVGBezierLine >> element: anElement points: somePoints width: anInteger color:
 ]
 
 { #category : #accessing }
-RTSVGBezierLine >> element: anElement points: somePoints width: anInteger color: aColor decoration: aLineDecoration [
-	self element: anElement points: somePoints width: anInteger color: aColor.
-	self decoration: aLineDecoration
+RTSVGBezierLine >> element: anElement points: somePoints width: anInteger color: aColor decorationsInfo: anArrayOfDecorationInfo [
+
+	self
+		element: anElement
+		points: somePoints
+		width: anInteger
+		color: aColor.
+	self decorationsInfo: anArrayOfDecorationInfo
 ]
 
 { #category : #initialization }
 RTSVGBezierLine >> initialize [
+
+	super initialize.
 	self type: 'path'.
 	self label: 'bezier'
 ]

--- a/src/Roassal2-Exporter/RTSVGCircleMarker.class.st
+++ b/src/Roassal2-Exporter/RTSVGCircleMarker.class.st
@@ -1,0 +1,13 @@
+Class {
+	#name : #RTSVGCircleMarker,
+	#superclass : #RTSVGAbstractMarker,
+	#category : #'Roassal2-Exporter-SVG'
+}
+
+{ #category : #adding }
+RTSVGCircleMarker >> addPath: stream [
+
+	stream nextPutAll:
+		(' d="M 0, <1p> a <1p>,<1p> 0 1,0 <2p>,0 a <1p>,<1p> 0 1,0 -<2p>,0" ' 
+			 expandMacrosWith: (xExtent / 2) rounded with: xExtent)
+]

--- a/src/Roassal2-Exporter/RTSVGDiamondMarker.class.st
+++ b/src/Roassal2-Exporter/RTSVGDiamondMarker.class.st
@@ -9,12 +9,26 @@ Class {
 }
 
 { #category : #adding }
-RTSVGDiamondMarker >> addPath: stream [	
-	stream
-		nextPutAll: (' d="M 0 0 L <1p> <2p> L 0 <3p> L -<1p> <2p> z" ' expandMacrosWith: xExtent with: ((yExtent/2) rounded) with: yExtent).
+RTSVGDiamondMarker >> addPath: stream [
+
+	stream nextPutAll:
+		(' d="M 0 5 l <2p> <1p> l <2p> -<1p> l -<2p> -<1p> z" '
+			 expandMacrosWith: (yExtent / 2) rounded
+			 with: (xExtent / 2) rounded)
 ]
 
 { #category : #adding }
 RTSVGDiamondMarker >> addSize: stream [
-	stream nextPutAll:  ('markerWidth = "<1p>" markerHeight = "<2p>" ' expandMacrosWith: (3 *size) with: size)
+
+	stream nextPutAll: ('markerWidth = "<1p>" markerHeight = "<2p>" '
+			 expandMacrosWith: 2 * size
+			 with: size)
+]
+
+{ #category : #initialization }
+RTSVGDiamondMarker >> initialize [
+
+	super initialize.
+	xExtent := 20.
+	yExtent := 10
 ]

--- a/src/Roassal2-Exporter/RTSVGEntity.class.st
+++ b/src/Roassal2-Exporter/RTSVGEntity.class.st
@@ -57,18 +57,14 @@ RTSVGEntity >> addExternalInteractions: aSVGVisitor [
 
 { #category : #style }
 RTSVGEntity >> addFillColor: stream [
+
 	self fillColor = nil
-		ifTrue: [
-			stream
-				nextPutAll: 'fill:none; '
-			  ]
-		ifFalse: [  
-			stream
-				nextPutAll:
-					('fill:rgb(<1p>,<2p>,<3p>); '
-						expandMacrosWith: (self fillColor red * 256) rounded
-						with: (self fillColor green * 256) rounded
-						with: (self fillColor blue * 256) rounded)]
+		ifTrue: [ stream nextPutAll: 'fill:none; ' ]
+		ifFalse: [ 
+			stream nextPutAll: ('fill:rgb(<1p>,<2p>,<3p>); '
+					 expandMacrosWith: (self fillColor red * 255) rounded
+					 with: (self fillColor green * 255) rounded
+					 with: (self fillColor blue * 255) rounded) ]
 ]
 
 { #category : #style }

--- a/src/Roassal2-Exporter/RTSVGGroupPopup.class.st
+++ b/src/Roassal2-Exporter/RTSVGGroupPopup.class.st
@@ -27,7 +27,7 @@ RTSVGGroupPopup >> addEventHandlers: aStream id: aString element: aRTElement cen
 		nextPutAll: String cr.
 	visitor := RTSVGVisitor new stream: aStream; center: aNumber; yourself.
 	visitor canvas: myGroup encompassingRectangle.
-	visitor visitGroup: myGroup.
+	myGroup accept: visitor.
 	aStream 
 		nextPutAll:  '</g>'
 ]

--- a/src/Roassal2-Exporter/RTSVGLine.class.st
+++ b/src/Roassal2-Exporter/RTSVGLine.class.st
@@ -12,7 +12,7 @@ Class {
 
 { #category : #adding }
 RTSVGLine >> addOn: stream using: aSVGVisitor [
-	
+
 	self id: (aSVGVisitor nameFor: self element).
 	self openDef: stream.
 	self addPosition: stream.
@@ -21,12 +21,11 @@ RTSVGLine >> addOn: stream using: aSVGVisitor [
 	self addStrokeOpacity: stream.
 	self addStrokeWidth: stream.
 	self closeTag: stream.
-	self decoration ifNotNil: [ self addMarker: stream ].
+	self addMarkers: stream.
 	self startClass: stream.
 	self closeTag: stream.
 	self addExternalInteractions: aSVGVisitor.
-	self closeDef: stream.
-	
+	self closeDef: stream
 ]
 
 { #category : #adding }
@@ -48,9 +47,15 @@ RTSVGLine >> element: anElement from: aPoint to: anotherPoint width: anInteger c
 ]
 
 { #category : #accessing }
-RTSVGLine >> element: anElement from: aPoint to: anotherPoint width: anInteger color: aColor decoration: aLineDecoration [
-	self element: anElement from: aPoint to: anotherPoint  width: anInteger color: aColor.
-	self decoration: aLineDecoration 
+RTSVGLine >> element: anElement from: aPoint to: anotherPoint width: anInteger color: aColor decorationsInfo: anArrayOfDecorationInfo [
+
+	self
+		element: anElement
+		from: aPoint
+		to: anotherPoint
+		width: anInteger
+		color: aColor.
+	self decorationsInfo: anArrayOfDecorationInfo
 ]
 
 { #category : #accessing }
@@ -65,6 +70,8 @@ RTSVGLine >> extent: anObject [
 
 { #category : #initialization }
 RTSVGLine >> initialize [
+
+	super initialize.
 	self type: 'line'.
 	self label: 'line'
 ]

--- a/src/Roassal2-Exporter/RTSVGStringConverter.class.st
+++ b/src/Roassal2-Exporter/RTSVGStringConverter.class.st
@@ -1,143 +1,20 @@
 "
-A RTSVGStringConverter is a class used to fix Strings before using them inside SVG elements. Since many characters need to be translated to its HTML standart encoding
+A RTHTMLStringConverter is a class used to fix Strings before using them inside HTML elements. Since many characters need to be translated to its HTML standart encoding
 "
 Class {
 	#name : #RTSVGStringConverter,
-	#superclass : #RTObject,
-	#instVars : [
-		'convertions'
-	],
+	#superclass : #RTHTMLStringConverter,
 	#category : #'Roassal2-Exporter-SVG'
 }
 
-{ #category : #converting }
-RTSVGStringConverter >> convertString: aString [
-	| array |
-	array := (1 to: aString size) collect: [ :n | convertions at: (aString at: n) ifAbsent: [ aString at: n ] ].
-	^ array inject: '' into: [ :acc :e | acc, (e asString) ].
-	
-]
-
-{ #category : #initialization }
-RTSVGStringConverter >> initialize [
-	super initialize.
-	convertions := Dictionary new.
-	self initializeValues.
-]
-
-{ #category : #initialization }
+{ #category : #accessing }
 RTSVGStringConverter >> initializeValues [
-	convertions 
-		at: $™ put: '&#8482;';
-		at: $\ put: '&#92;';
-		at: $€ put: '&euro;';
-		at: $  put: '&#160;';
+
+	convertions
 		at: $" put: '&quot;';
+		at: $' put: '&apos;';
 		at: $& put: '&amp;';
 		at: $< put: '&lt;';
 		at: $> put: '&gt;';
-		at: $¡ put: '&iexcl;';
-		at: $¢ put: '&cent;';
-		at: $£ put: '&pound;';
-		at: $¤ put: '&curren;';
-		at: $¥ put: '&yen;';
-		at: $¦ put: '&brvbar;';
-		at: $§ put: '&sect;';
-		at: $¨ put: '&uml;';
-		at: $© put: '&copy;';
-		at: $ª put: '&ordf;';
-		at: $¬ put: '&not;';
-		at: $® put: '&reg;';
-		at: $¯ put: '&macr;';
-		at: $° put: '&deg;';
-		at: $± put: '&plusmn;';
-		at: $² put: '&sup2;';
-		at: $³ put: '&sup3;';
-		at: $´ put: '&acute;';
-		at: $µ put: '&micro;';
-		at: $¶ put: '&para;';
-		at: $· put: '&middot;';
-		at: $¸ put: '&cedil;';
-		at: $¹ put: '&sup1;';
-		at: $º put: '&ordm;';
-		at: $» put: '&raquo;';
-		at: $¼ put: '&frac14;';
-		at: $½ put: '&frac12;';
-		at: $¾ put: '&frac34;';
-		at: $¿ put: '&iquest;';
-		at: $À put: '&Agrave;';
-		at: $Á put: '&Aacute;';
-		at: $Â put: '&Acirc;';
-		at: $Ã put: '&Atilde;';
-		at: $Ä put: '&#196;';
-		at: $Å put: '&Aring;';
-		at: $Æ put: '&AElig;';
-		at: $Ç put: '&Ccedil;';
-		at: $È put: '&Egrave;';
-		at: $É put: '&Eacute;';
-		at: $Ê put: '&Ecirc;';
-		at: $Ë put: '&Euml;';
-		at: $Ì put: '&Igrave;';
-		at: $Í put: '&Iacute;';
-		at: $Î put: '&Icirc;';
-		at: $Ï put: '&Iuml;';
-		at: $Ð put: '&ETH;';
-		at: $Ñ put: '&Ntilde;';
-		at: $Ò put: '&Ograve;';
-		at: $Ó put: '&Oacute;';
-		at: $Ô put: '&Ocirc;';
-		at: $Õ put: '&Otilde;';
-		at: $Ö put: '&Ouml;';
-		at: $× put: '&times;';
-		at: $Ø put: '&Oslash;';
-		at: $Ù put: '&Ugrave;';
-		at: $Ú put: '&Uacute;';
-		at: $Û put: '&Ucirc;';
-		at: $Ü put: '&Uuml;';
-		at: $Ý put: '&Yacute;';
-		at: $Þ put: '&THORN;';
-		at: $ß put: '&szlig;';
-		at: $à put: '&agrave;';
-		at: $á put: '&aacute;';
-		at: $â put: '&acirc;';
-		at: $ã put: '&atilde;';
-		at: $ä put: '&#228;';
-		at: $å put: '&aring;';
-		at: $æ put: '&aelig;';
-		at: $ç put: '&ccedil;';
-		at: $è put: '&egrave;';
-		at: $é put: '&eacute;';
-		at: $ê put: '&ecirc;';
-		at: $ë put: '&euml;';
-		at: $ì put: '&igrave;';
-		at: $í put: '&iacute;';
-		at: $î put: '&icirc;';
-		at: $ï put: '&iuml;';
-		at: $ð put: '&eth;';
-		at: $ñ put: '&ntilde;';
-		at: $ò put: '&ograve;';
-		at: $ó put: '&oacute;';
-		at: $ô put: '&ocirc;';
-		at: $õ put: '&otilde;';
-		at: $ö put: '&ouml;';
-		at: $÷ put: '&divide;';
-		at: $ø put: '&oslash;';
-		at: $ù put: '&ugrave;';
-		at: $ú put: '&uacute;';
-		at: $û put: '&ucirc;';
-		at: $ü put: '&uuml;';
-		at: $ý put: '&yacute;';
-		at: $þ put: '&thorn;';
-		at: $⁰ put: '&#8304;';
-		at: $¹ put: '&#185;';
-		at: $² put: '&#178;';
-		at: $³ put: '&#179;';
-		at: $⁴ put: '&#8308;';
-		at: $⁵ put: '&#8309;';
-		at: $⁶ put: '&#8310;';
-		at: $⁷ put: '&#8311;';
-		at: $⁸ put: '&#8312;';
-		at: $⁹ put: '&#8313;';
-		
-		at: Character cr put: ''.
+		at: Character cr put: ''
 ]

--- a/src/Roassal2-Exporter/RTSVGVisitor.class.st
+++ b/src/Roassal2-Exporter/RTSVGVisitor.class.st
@@ -283,6 +283,12 @@ RTSVGVisitor >> visitAbstractLineDecorationShape: anAbstractLineDecoration [
 ]
 
 { #category : #visitor }
+RTSVGVisitor >> visitArcLine: aLineArc [
+
+	self notYetImplemented
+]
+
+{ #category : #visitor }
 RTSVGVisitor >> visitArcShape: aShape [
 	|sCenter svgE|
 	sCenter := self alignPoint: (aShape position).
@@ -423,6 +429,14 @@ RTSVGVisitor >> visitEllipseShape: anEllipse [
 	box := self alignRectangle: (anEllipse encompassingRectangle).
 	svgE := RTSVGOval new element: anEllipse box: box color: fillColor borderWidth: 1 borderColor: borderColor.
 	svgE addOn: stream using: self.
+]
+
+{ #category : #visitor }
+RTSVGVisitor >> visitGrid: aGridShape [
+
+	"do not draw a grid"
+
+	
 ]
 
 { #category : #visitor }

--- a/src/Roassal2-Exporter/RTSVGVisitor.class.st
+++ b/src/Roassal2-Exporter/RTSVGVisitor.class.st
@@ -152,6 +152,15 @@ RTSVGVisitor >> center: aPoint [
 	center := aPoint
 ]
 
+{ #category : #utils }
+RTSVGVisitor >> findDecorationInfoForLines: lines outOfDecorations: decorations [
+
+	^ (lines collect: [ :eachLine | 
+		   eachLine
+		   -> (self getDecorationInfoOutOf: decorations forLine: eachLine) ])
+		  asDictionary
+]
+
 { #category : #alignment }
 RTSVGVisitor >> fixedEncompassingRectangle [
  	| shapes |
@@ -167,30 +176,34 @@ RTSVGVisitor >> fixedEncompassingRectangle [
 ]
 
 { #category : #utils }
-RTSVGVisitor >> getCorrespondingLine: decorator from: lines [
-	lines do: [ :l |
-		(l class = TRBezierShape) 
-			ifTrue: [ decorator to = l points last 
-				ifTrue: [
-					lines remove: l. 
-					^ Array with: l with: decorator ] ]
-			ifFalse: [ decorator to = l to ifTrue: [ 
-					lines remove: l. 
-					^ Array with: l with: decorator ] ].
-		 ].
-	^nil
-]
+RTSVGVisitor >> getDecorationInfoOutOf: decorators forLine: line [
 
-{ #category : #utils }
-RTSVGVisitor >> getDecorationId: aLineDecorationShape [
-	|t w c s lw|
-	t := aLineDecorationShape class name.
-	w := aLineDecorationShape mySize.
-	c := aLineDecorationShape color.
-	s := aLineDecorationShape strokePaint.
-	lw := aLineDecorationShape width.
-	^(t asString, w asString, ((c red * 256) + (s red * 256)) rounded asString, ((c green * 256) + (s green * 256)) rounded asString, ((c blue * 256) + (s blue * 256)) rounded asString, lw asString)
-	
+	| tailDecorator headDecorator |
+	tailDecorator := nil.
+	headDecorator := nil.
+	decorators do: [ :decorator | 
+		decorator to = line to
+			ifTrue: [ 
+				headDecorator := RTLineDecorationInfo
+					                 line: line
+					                 decoration: decorator.
+				tailDecorator ifNotNil: [ 
+					^ { 
+						  headDecorator.
+						  tailDecorator } ] ]
+			ifFalse: [ 
+				decorator to = line from ifTrue: [ 
+					tailDecorator := RTLineDecorationInfo
+						                 line: line
+						                 decorationOnStart: decorator.
+					headDecorator ifNotNil: [ 
+						^ { 
+							  headDecorator.
+							  tailDecorator } ] ] ] ].
+	headDecorator
+		ifNil: [ tailDecorator ifNotNil: [ ^ { tailDecorator } ] ]
+		ifNotNil: [ ^ { headDecorator } ].
+	^ #(  )
 ]
 
 { #category : #initialization }
@@ -212,6 +225,12 @@ RTSVGVisitor >> interactions: anObject [
 	interactions := anObject
 ]
 
+{ #category : #visitor }
+RTSVGVisitor >> lineClasses [
+
+	^ TRAbstractLineShape allSubclasses
+]
+
 { #category : #accessing }
 RTSVGVisitor >> names [
 	^ names
@@ -220,17 +239,6 @@ RTSVGVisitor >> names [
 { #category : #accessing }
 RTSVGVisitor >> names: anObject [
 	names := anObject
-]
-
-{ #category : #utils }
-RTSVGVisitor >> separateDecorated: lines decorations: decorations [
-	|decorated temp |
-	decorated := OrderedCollection new.
-	decorations do: [ :d | 
-		temp := (self getCorrespondingLine: d from: lines).
-		decorated add: temp.
-		].
-	^decorated
 ]
 
 { #category : #visitor }
@@ -271,18 +279,6 @@ RTSVGVisitor >> visit [
 ]
 
 { #category : #visitor }
-RTSVGVisitor >> visitAbstractLine: anAbstractLine [
-	anAbstractLine accept: anAbstractLine
-	
-]
-
-{ #category : #visitor }
-RTSVGVisitor >> visitAbstractLineDecorationShape: anAbstractLineDecoration [
-	anAbstractLineDecoration accept: anAbstractLineDecoration
-	
-]
-
-{ #category : #visitor }
 RTSVGVisitor >> visitArcLine: aLineArc [
 
 	self notYetImplemented
@@ -296,39 +292,19 @@ RTSVGVisitor >> visitArcShape: aShape [
 	svgE addOn: stream using: self. 
 ]
 
-{ #category : #visitor }
-RTSVGVisitor >> visitArrowHeadShape: arrowHeadShape [
-	| aid color bColor w s svgE|
-	aid := self getDecorationId: arrowHeadShape.
-	color := arrowHeadShape color.
-	bColor := arrowHeadShape strokePaint.
-	w := arrowHeadShape width.
-	s := arrowHeadShape mySize.
-	(markers contains: aid)
-		ifFalse: [  
-			svgE := RTSVGArrowHeadMarker new id: aid fillColor: color borderColor: bColor width: w size: s.
-			svgE addOn: stream using: self. 
-			markers add: aid. 
-			]
-		
-	
+{ #category : #'visitor-decorations' }
+RTSVGVisitor >> visitArrowHeadShape: arrowHeadShape onStart: aBoolean [
+
+	self
+		visitLineDecorationShape: arrowHeadShape
+		using: RTSVGArrowHeadMarker
+		onStart: aBoolean
 ]
 
-{ #category : #visitor }
-RTSVGVisitor >> visitArrowShape: arrowShape [
-	| aid bColor w s svgE|
-	aid := self getDecorationId: arrowShape.
-	bColor := arrowShape strokePaint.
-	w := arrowShape width.
-	s := arrowShape mySize.
-	(markers includes: aid)
-		ifFalse: [ 
-			svgE := RTSVGArrowMarker new id: aid fillColor: nil borderColor: bColor width: w size: s.
-			svgE addOn: stream using: self. 
-			markers add: aid. 
-			]
-		
-	
+{ #category : #'visitor-decorations' }
+RTSVGVisitor >> visitArrowShape: arrowShape onStart: aBoolean [
+
+	self visitLineDecorationShape: arrowShape using: RTSVGArrowMarker onStart: aBoolean
 ]
 
 { #category : #visitor }
@@ -345,11 +321,11 @@ RTSVGVisitor >> visitBezierShape: aBezierShape [
 ]
 
 { #category : #visitor }
-RTSVGVisitor >> visitBezierShape: aBezierShape with: aLineDecoration [
+RTSVGVisitor >> visitBezierShape: aBezierShape with: anArrayOfDecorationInfo [
 	|points svgE|
 	points:= aBezierShape points copy.
 	points := points collect: [ :p | self alignPoint: p].
-	svgE := RTSVGBezierLine new element: (aBezierShape) points: points width: (aBezierShape width) color: (aBezierShape strokePaint) decoration: aLineDecoration.
+	svgE := RTSVGBezierLine new element: (aBezierShape) points: points width: (aBezierShape width) color: (aBezierShape strokePaint) decorationsInfo: anArrayOfDecorationInfo.
 	svgE addOn: stream using: self. 
 ]
 
@@ -379,43 +355,46 @@ RTSVGVisitor >> visitBoxShape: aBox [
 
 { #category : #visitor }
 RTSVGVisitor >> visitCanvas: aCanvas [
-	|elementShapes edgeShapes decoratedEdgeShapes decorationShapes nonDecorationShapes lineClasses lineDecorationClasses canvasShapes|
-	
-	
+
+	| elementShapes edgeShapes decorationInfoByLines decorationShapes nonDecorationShapes lineClasses lineDecorationClasses canvasShapes |
 	canvasShapes := aCanvas shapes.
-	lineClasses := Array with: TRLineShape with: TRBezierShape.
-	lineDecorationClasses := TRAbstractLineDecoratorShape withAllSubclasses.
-	elementShapes := canvasShapes reject: [ :e |  (lineClasses includes: e class)  or: [ lineDecorationClasses includes: e class  ]].
-	edgeShapes := (canvasShapes select: [ :e |  (lineClasses includes: e class)] ) asOrderedCollection.
-	nonDecorationShapes := (canvasShapes reject: [ :e | lineDecorationClasses includes: e class ]) asOrderedCollection.
-	decorationShapes := canvasShapes select: [ :e |  lineDecorationClasses includes: e class].
-	decoratedEdgeShapes := self separateDecorated: edgeShapes decorations: decorationShapes.
-	
-	stream 
-		nextPutAll: '<defs>'.
-	decorationShapes do: [:s | s accept: self ].
-	stream 
-		nextPutAll: '</defs>'.
-	nonDecorationShapes do:[:s | s accept: self].
-	decoratedEdgeShapes do:[:p | p first accept: self with: p second].
+	lineClasses := self lineClasses.
+	lineDecorationClasses := TRAbstractLineDecoratorShape
+		                         withAllSubclasses.
+	elementShapes := canvasShapes reject: [ :e | 
+		                 (lineClasses includes: e class) or: [ 
+			                 lineDecorationClasses includes: e class ] ].
+	edgeShapes := (canvasShapes select: [ :e | 
+		               lineClasses includes: e class ]) asOrderedCollection.
+	nonDecorationShapes := (canvasShapes reject: [ :e | 
+		                        lineDecorationClasses includes: e class ])
+		                       asOrderedCollection.
+	decorationShapes := canvasShapes select: [ :e | 
+		                    lineDecorationClasses includes: e class ].
+
+	decorationInfoByLines := self
+		                         findDecorationInfoForLines: edgeShapes
+		                         outOfDecorations: decorationShapes.
+	stream nextPutAll: '<defs>'.
+	decorationInfoByLines do: [ :eachArrayOfInfo | 
+		eachArrayOfInfo do: [ :eachInfo | 
+			eachInfo decoration accept: self onStart: eachInfo isOnStart ] ].
+	stream nextPutAll: '</defs>'.
+	nonDecorationShapes do: [ :s | s accept: self ].
+	decorationInfoByLines associationsDo: [ :eachAssociation | 
+		eachAssociation key accept: self with: eachAssociation value ]
 ]
 
-{ #category : #visitor }
-RTSVGVisitor >> visitDiamondShape: diamondShape [
-	| aid color bColor w s svgE|
-	aid := self getDecorationId: diamondShape.
-	color := diamondShape color.
-	bColor := diamondShape strokePaint.
-	w := diamondShape width.
-	s := diamondShape mySize.
-	(markers contains: aid)
-		ifFalse: [  
-			svgE := RTSVGDiamondMarker new id: aid fillColor: color borderColor: bColor width: w size: s.
-			svgE addOn: stream using: self. 
-			markers add: aid. 
-			]
-		
-	
+{ #category : #'visitor-decorations' }
+RTSVGVisitor >> visitCircleHeadShape: shape onStart: aBoolean [
+
+	self visitLineDecorationShape: shape using: RTSVGCircleMarker onStart: aBoolean
+]
+
+{ #category : #'visitor-decorations' }
+RTSVGVisitor >> visitDiamondShape: diamondShape onStart: aBoolean [
+
+	self visitLineDecorationShape: diamondShape using: RTSVGDiamondMarker onStart: aBoolean
 ]
 
 { #category : #visitor }
@@ -440,11 +419,6 @@ RTSVGVisitor >> visitGrid: aGridShape [
 ]
 
 { #category : #visitor }
-RTSVGVisitor >> visitGroup: aRTGroup [
-	aRTGroup accept: self.
-]
-
-{ #category : #visitor }
 RTSVGVisitor >> visitLabelShape: aLabel [
 	| color rectangle position text svgE|
 	color := aLabel color.	
@@ -460,6 +434,30 @@ RTSVGVisitor >> visitLabelShape: aLabel [
 	svgE addOn: stream using: self.
 ]
 
+{ #category : #'visitor-decorations' }
+RTSVGVisitor >> visitLineDecorationShape: shape using: svgShapeClass onStart: aBoolean [
+
+	| aid color bColor w s svgE decorationInfo |
+	decorationInfo := RTLineDecorationInfo new decoration: shape.
+	aBoolean ifTrue: [ decorationInfo onStart ].
+	aid := RTSVGAbstractLine getDecorationId: decorationInfo.
+	color := shape color.
+	bColor := shape strokePaint.
+	w := shape width.
+	s := shape mySize.
+	(markers includes: aid) ifFalse: [ 
+		svgE := svgShapeClass new
+			        id: aid
+			        fillColor: color
+			        borderColor: bColor
+			        width: w
+			        size: s;
+			        yourself.
+		aBoolean ifTrue: [ svgE onStart ].
+		svgE addOn: stream using: self.
+		markers add: aid ]
+]
+
 { #category : #visitor }
 RTSVGVisitor >> visitLineShape: aLine [
 	|startingPoint endingPoint svgE|
@@ -470,17 +468,30 @@ RTSVGVisitor >> visitLineShape: aLine [
 ]
 
 { #category : #visitor }
-RTSVGVisitor >> visitLineShape: aLine with: aLineDecoration [
-	|startingPoint endingPoint svgE|
-	startingPoint := self alignPoint: (aLine from).
-	endingPoint := self alignPoint: (aLine to).
-	svgE := RTSVGLine new element: (aLine) from: startingPoint to: endingPoint width: 1 color: (aLine strokePaint) decoration: aLineDecoration.
-	svgE addOn: stream using: self. 
+RTSVGVisitor >> visitLineShape: aLine with: anArrayOfDecorationInfo [
+
+	| startingPoint endingPoint svgE |
+	startingPoint := self alignPoint: aLine from.
+	endingPoint := self alignPoint: aLine to.
+	svgE := RTSVGLine new
+		        element: aLine
+		        from: startingPoint
+		        to: endingPoint
+		        width: 1
+		        color: aLine strokePaint
+		        decorationsInfo: anArrayOfDecorationInfo.
+	svgE addOn: stream using: self
 ]
 
 { #category : #visitor }
 RTSVGVisitor >> visitMondrianViewBuilder: aView [
 	aView view accept: self
+]
+
+{ #category : #'visitor-decorations' }
+RTSVGVisitor >> visitNarrowArrowHeadShape: arrowHeadShape onStart: aBoolean [
+
+	self visitArrowHeadShape: arrowHeadShape onStart: aBoolean
 ]
 
 { #category : #visitor }

--- a/src/Roassal2-Kiviat/RTKiviatBuilder.class.st
+++ b/src/Roassal2-Kiviat/RTKiviatBuilder.class.st
@@ -256,11 +256,11 @@ RTKiviatBuilder >> executeHighlightLowColor: lowColor highColor: highColor [
 		self kiviatMetrics do: [ :m | titles add: (view elements detect: [ :e |  (e shape isKindOf: RTLabel) and: [ (e trachelShape text) = (m named) ] ])].
 		 ].
 
-	((kiviatNodes flatCollect: [ :kn | kn nodeKiviatElements]) asGroup) do: [  :e | 
+	((kiviatNodes flatCollect: [ :kn | kn nodeKiviatElements]) asRTGroup) do: [  :e | 
 		e @ (RTShowLabel new labelledInteraction: (RTLabeled new text: [ :el | el kiviatNode named])).
 		].
 	
-	((kiviatNodes flatCollect: [ :kn | kn nodeKiviatElements]) asGroup)  when: TRMouseEnter do: [  :evt | 
+	((kiviatNodes flatCollect: [ :kn | kn nodeKiviatElements]) asRTGroup)  when: TRMouseEnter do: [  :evt | 
 		(kiviatNodes select: [ :kn | kn named = evt element model kiviatNode named ]) do: [ :kn |
 			
 			kn nodeKiviatElements do: [ :e | self recordElement: e. e trachelShape color: (e trachelShape color alpha: highColor)].
@@ -274,7 +274,7 @@ RTKiviatBuilder >> executeHighlightLowColor: lowColor highColor: highColor [
 		view signalUpdate.
 		].
 	
-	((kiviatNodes flatCollect: [ :kn | kn nodeKiviatElements]) asGroup) when: TRMouseLeave do: [  :evt | 
+	((kiviatNodes flatCollect: [ :kn | kn nodeKiviatElements]) asRTGroup) when: TRMouseLeave do: [  :evt | 
 		kiviatNodes do: [ :kn |
 			kn nodeKiviatElements do: [ :e | e trachelShape color: (e attributes at: #originalColor)].
 			kn edgeKiviatElements do: [ :e | e trachelShape color: (e attributes at: #originalColor)].

--- a/src/Roassal2-Tests/RTInteractionBuilderTest.class.st
+++ b/src/Roassal2-Tests/RTInteractionBuilderTest.class.st
@@ -42,7 +42,7 @@ RTInteractionBuilderTest >> testAddingTwoActions [
 	self assert: builder numberOfInteractions equals: 2.
 	
 	e := RTElement new.
-	builder setUpElements: (Array with: e) asGroup.
+	builder setUpElements: (Array with: e) asRTGroup.
 	self assert: e announcer numberOfSubscriptions equals: 1.
 	
 ]

--- a/src/Roassal2-Tests/RTJavascriptVisitorTest.class.st
+++ b/src/Roassal2-Tests/RTJavascriptVisitorTest.class.st
@@ -2,7 +2,7 @@
 I am a simple test class for RTSVGVisitor2
 "
 Class {
-	#name : #RTSVGVisitor2Test,
+	#name : #RTJavascriptVisitorTest,
 	#superclass : #RTTest,
 	#instVars : [
 		'visitor'
@@ -11,14 +11,14 @@ Class {
 }
 
 { #category : #running }
-RTSVGVisitor2Test >> setUp [
+RTJavascriptVisitorTest >> setUp [
 	super setUp.
 	visitor := RTJavascriptVisitor new.
 	
 ]
 
 { #category : #tests }
-RTSVGVisitor2Test >> testAddInteractions [
+RTJavascriptVisitorTest >> testAddInteractions [
 	| element |
 	element := RTBox new borderColor: Color black; elementOn: 1.
 	element @ RTDraggable.
@@ -27,7 +27,7 @@ RTSVGVisitor2Test >> testAddInteractions [
 ]
 
 { #category : #tests }
-RTSVGVisitor2Test >> testAddMatrix [
+RTJavascriptVisitorTest >> testAddMatrix [
 	| el |
 	el := RTBox new element.
 	el translateTo: 0 @ 0.5.
@@ -36,7 +36,7 @@ RTSVGVisitor2Test >> testAddMatrix [
 ]
 
 { #category : #tests }
-RTSVGVisitor2Test >> testAddPopup [
+RTJavascriptVisitorTest >> testAddPopup [
 	| element background |
 	element := RTBox new borderColor: Color black; elementOn: 1.
 	element @ (RTPopup new group: [ :group :el |
@@ -53,7 +53,7 @@ RTSVGVisitor2Test >> testAddPopup [
 ]
 
 { #category : #tests }
-RTSVGVisitor2Test >> testBasic [
+RTJavascriptVisitorTest >> testBasic [
 	| size |
 	self assert: visitor view isNil.
 	self assert: visitor stream contents isEmpty.
@@ -69,7 +69,7 @@ RTSVGVisitor2Test >> testBasic [
 ]
 
 { #category : #tests }
-RTSVGVisitor2Test >> testBorderWidth [
+RTJavascriptVisitorTest >> testBorderWidth [
 	| el |
 	el := RTBox new borderColor: Color black; element.
 	visitor addBorderWidth: el trachelShape.
@@ -77,7 +77,7 @@ RTSVGVisitor2Test >> testBorderWidth [
 ]
 
 { #category : #tests }
-RTSVGVisitor2Test >> testVisitArcShape [
+RTJavascriptVisitorTest >> testVisitArcShape [
 	| el |
 	el := (RTArc new  betaAngle: 0; innerRadius: 30; externalRadius: 30) element.
 	visitor visitElement: el.
@@ -86,7 +86,7 @@ RTSVGVisitor2Test >> testVisitArcShape [
 ]
 
 { #category : #tests }
-RTSVGVisitor2Test >> testVisitArrowShape [
+RTJavascriptVisitorTest >> testVisitArrowShape [
 	| shape box e1 e2 view |
 	view := RTView new.
 	box := RTBox new.
@@ -110,7 +110,7 @@ RTSVGVisitor2Test >> testVisitArrowShape [
 ]
 
 { #category : #tests }
-RTSVGVisitor2Test >> testVisitBoxShape [
+RTJavascriptVisitorTest >> testVisitBoxShape [
 	| box |
 	box := RTBox new size: 1/2; elementOn: 'foo'.
 	visitor visitElement: box.
@@ -119,7 +119,7 @@ RTSVGVisitor2Test >> testVisitBoxShape [
 ]
 
 { #category : #tests }
-RTSVGVisitor2Test >> testVisitEllipseShape [
+RTJavascriptVisitorTest >> testVisitEllipseShape [
 	| ellipse |
 	ellipse := RTEllipse new size: 1/2; elementOn: 'foo'.
 	visitor visitElement: ellipse.
@@ -128,7 +128,7 @@ RTSVGVisitor2Test >> testVisitEllipseShape [
 ]
 
 { #category : #tests }
-RTSVGVisitor2Test >> testVisitGroup [
+RTJavascriptVisitorTest >> testVisitGroup [
 	| group |
 	group := RTGroup new.
 	group add: RTBox element.
@@ -138,7 +138,7 @@ RTSVGVisitor2Test >> testVisitGroup [
 ]
 
 { #category : #tests }
-RTSVGVisitor2Test >> testVisitLineShape [
+RTJavascriptVisitorTest >> testVisitLineShape [
 	| shape box e1 e2 |
 	box := RTBox new.
 	e1 := box element.
@@ -150,7 +150,7 @@ RTSVGVisitor2Test >> testVisitLineShape [
 ]
 
 { #category : #tests }
-RTSVGVisitor2Test >> testVisitPolygonShape [
+RTJavascriptVisitorTest >> testVisitPolygonShape [
 	| shape |
 	shape := RTPolygon new 
 		vertices: (Array with: 0@0 with: 1@0 with: 1@1); elementOn: 'foo'.
@@ -160,7 +160,7 @@ RTSVGVisitor2Test >> testVisitPolygonShape [
 ]
 
 { #category : #tests }
-RTSVGVisitor2Test >> testVisitSVGPath [
+RTJavascriptVisitorTest >> testVisitSVGPath [
 	| shape |
 	shape := RTSVGPath new path:'M 100 100 L 300 100 L 200 300 z'; element.
 	

--- a/src/Roassal2/Collection.extension.st
+++ b/src/Roassal2/Collection.extension.st
@@ -2,19 +2,37 @@ Extension { #name : #Collection }
 
 { #category : #'*Roassal2' }
 Collection >> asGroup [
-	^ RTGroup withAll: self
+
+	self
+		deprecated: 'Use #asRTGroup for Roassal3/Pharo9+ compatibility'
+		on: '2022-03-18'
+		in: #Pharo9
+		transformWith: '`@receiver asGroup' -> '`@receiver asRTGroup'.
+	^ self asRTGroup
 ]
 
 { #category : #'*Roassal2' }
 Collection >> asIdentityGroup [
-	^ RTIdentityGroup withAll: self
-	
 
+	self
+		deprecated:
+		'Use #asRTIdentityGroup for Roassal3/Pharo9+ compatibility'
+		on: '2022-03-18'
+		in: #Pharo9
+		transformWith:
+		'`@receiver asIdentityGroup' -> '`@receiver asRTIdentityGroup'.
+	^ self asRTIdentityGroup
 ]
 
 { #category : #'*Roassal2' }
 Collection >> asRTGroup [
 	^ RTGroup withAll: self
+]
+
+{ #category : #'*Roassal2' }
+Collection >> asRTIdentityGroup [
+
+	^ RTIdentityGroup withAll: self
 ]
 
 { #category : #'*Roassal2' }

--- a/src/Roassal2/RTBuilder.class.st
+++ b/src/Roassal2/RTBuilder.class.st
@@ -211,7 +211,7 @@ RTBuilder >> setCurrentShape: aShape [
 { #category : #protected }
 RTBuilder >> setUpInteractionFor: oneOrMoreElements [
 	"This method may be used in subclasses to set up the interaction on the elements provided as argument"
-	interactionBuilder setUpElements: oneOrMoreElements asGroup
+	interactionBuilder setUpElements: oneOrMoreElements asRTGroup
 ]
 
 { #category : #accessing }

--- a/src/Roassal2/RTCache.class.st
+++ b/src/Roassal2/RTCache.class.st
@@ -32,8 +32,8 @@ RTCache >> cacheElements: someElements edges: someEdges [
 	"This method is assuming all the elements belong to the same view"
 	| view newElement elements edges |
 	
-	elements := someElements asGroup.
-	edges := someEdges asGroup.
+	elements := someElements asRTGroup.
+	edges := someEdges asRTGroup.
 	view := someElements anyOne view.
 	canvas := view canvas.
 	trachelShapes := canvas shapes.

--- a/src/Roassal2/RTExploraBuilder.class.st
+++ b/src/Roassal2/RTExploraBuilder.class.st
@@ -82,10 +82,10 @@ RTExploraBuilder >> buildNode: object parent: parent [
 		elementIconOpen := (icons first) elementOn: #iconOpen.
 		elementIconClose := (icons second) elementOn: #iconClose.
 		
-		RTConstraint move: ((Array with: elementIconOpen with: elementIconClose) asGroup) onTheRightOf: element.
+		RTConstraint move: ((Array with: elementIconOpen with: elementIconClose) asRTGroup) onTheRightOf: element.
 
 		element addCallback: (TRTranslationCallback new block: [
-			TRConstraint move: ((Array with: elementIconOpen with: elementIconClose) asGroup) onTheRightOf:element. 		
+			TRConstraint move: ((Array with: elementIconOpen with: elementIconClose) asRTGroup) onTheRightOf:element. 		
 			self view signalUpdate
 			]).
 	

--- a/src/Roassal2/RTExploraBuilderLazy.class.st
+++ b/src/Roassal2/RTExploraBuilderLazy.class.st
@@ -28,10 +28,10 @@ RTExploraBuilderLazy >> buildNode: object parent: parent [
 		elementIconOpen := (icons first) elementOn: #iconOpen.
 		elementIconClose := (icons second) elementOn: #iconClose.
 		
-		RTConstraint move: ((Array with: elementIconOpen with: elementIconClose) asGroup) onTheRightOf: element.
+		RTConstraint move: ((Array with: elementIconOpen with: elementIconClose) asRTGroup) onTheRightOf: element.
 
 		element addCallback: (TRTranslationCallback new block: [
-			TRConstraint move: ((Array with: elementIconOpen with: elementIconClose) asGroup) onTheRightOf:element. 		
+			TRConstraint move: ((Array with: elementIconOpen with: elementIconClose) asRTGroup) onTheRightOf:element. 		
 			self view signalUpdate
 			]).
 	

--- a/src/Roassal2/RTExploraNode.class.st
+++ b/src/Roassal2/RTExploraNode.class.st
@@ -62,7 +62,7 @@ RTExploraNode >> addListenerFor: anEvent onDirection: aDirection withBlock: aBlo
 	| listener |
 	
 	listener := element.
-	iconOpen ifNotNil: [ listener := (Array with: iconOpen with: iconClose) asGroup ].
+	iconOpen ifNotNil: [ listener := (Array with: iconOpen with: iconClose) asRTGroup ].
 		
 	self addExpansionDirection: aDirection.
 	self expandWithBlock: aBlock onDirection: aDirection.
@@ -74,7 +74,7 @@ RTExploraNode >> addListenerFor: anEvent onDirection: aDirection withBlock: aBlo
 			ifFalse: [ self exploreOnDirection: aDirection ].
 			((builder layout rtValue: self)
 				translator: (RTSmoothLayoutTranslator new nbCycles: 0.25))
-				on: ((builder nodes collect: [ :n | n element ]) asGroup).	
+				on: ((builder nodes collect: [ :n | n element ]) asRTGroup).	
 		element view canvas signalUpdate].
 	
 
@@ -197,7 +197,7 @@ RTExploraNode >> explorationStatus: aDirection [
 { #category : #action }
 RTExploraNode >> exploreOnDirection: aDirection [
 	| objs objectsToAdd newNodes nodesAlreadyIn objsAlreadyIn |
-	objs := ((builder nodes collect: [ :n | n element ]) asGroup) collect: [ :el | el model ].
+	objs := ((builder nodes collect: [ :n | n element ]) asRTGroup) collect: [ :el | el model ].
 	objectsToAdd := self expansionOnDirection: aDirection.
 	objsAlreadyIn := objectsToAdd select: [ :obj | objs includes: obj ].
 	objectsToAdd := objectsToAdd reject: [ :obj | objs includes: obj ].

--- a/src/Roassal2/RTExploraNodeLazy.class.st
+++ b/src/Roassal2/RTExploraNodeLazy.class.st
@@ -12,7 +12,7 @@ RTExploraNodeLazy >> addListenerFor: anEvent onDirection: aDirection withBlock: 
 	| listener |
 	
 	listener := element.
-	iconOpen ifNotNil: [ listener := (Array with: iconOpen with: iconClose) asGroup ].
+	iconOpen ifNotNil: [ listener := (Array with: iconOpen with: iconClose) asRTGroup ].
 		
 	self addExpansionDirection: aDirection.
 	
@@ -25,7 +25,7 @@ RTExploraNodeLazy >> addListenerFor: anEvent onDirection: aDirection withBlock: 
 			ifFalse: [ self exploreOnDirection: aDirection ].
 			((builder layout rtValue: self)
 				translator: (RTSmoothLayoutTranslator new nbCycles: 0.25))
-				on: ((builder nodes collect: [ :n | n element ]) asGroup).	
+				on: ((builder nodes collect: [ :n | n element ]) asRTGroup).	
 		element view canvas signalUpdate].
 	
 
@@ -37,7 +37,7 @@ RTExploraNodeLazy >> exploreOnDirection: aDirection [
 	
 	self expandWithBlock: block onDirection: aDirection.
 	
-	objs := ((builder nodes collect: [ :n | n element ]) asGroup) collect: [ :el | el model ].
+	objs := ((builder nodes collect: [ :n | n element ]) asRTGroup) collect: [ :el | el model ].
 	objectsToAdd := self expansionOnDirection: aDirection.
 	objsAlreadyIn := objectsToAdd select: [ :obj | objs includes: obj ].
 	objectsToAdd := objectsToAdd reject: [ :obj | objs includes: obj ].

--- a/src/Roassal2/RTGrapherDecorationExample.class.st
+++ b/src/Roassal2/RTGrapherDecorationExample.class.st
@@ -55,7 +55,7 @@ deco legendLabel text: [ :as | | pos year |
 b addDecorator: deco.
 b build.
 
-elements := (b view canvas shapes) asGroup.
+elements := (b view canvas shapes) asRTGroup.
 image := 'https://dl.dropboxusercontent.com/s/v5b7fg4gzb4w4xs/dota.jpeg?dl=0'.
 image := (TRPlatform current download: image ) contents.
 image := RTBitmap new 

--- a/src/Roassal2/RTGridView.class.st
+++ b/src/Roassal2/RTGridView.class.st
@@ -135,11 +135,12 @@ RTGridView >> initializeElement: aView [
 
 { #category : #hooks }
 RTGridView >> registerMovementEvents: aCanvas [
-	aCanvas camera
-		addCallback:
-			(TRTranslationCallback
-				block: [ :shape :step | 
-					gridShape addToOffset: step.
-					gridShape signalUpdate ]).
-	aCanvas when: TRMouseWheelEvent do: [ :e | gridShape resetPath ]
+
+	aCanvas camera addCallback:
+		(TRTranslationCallback block: [ :shape :step | 
+			 gridShape addToOffset: step.
+			 gridShape signalUpdate ]).
+	aCanvas camera addCallback:
+		(TRCameraScaleCallback block: [ :scaleFactor | gridShape resetPath ]).
+	aCanvas when: TRResizeCanvasEvent do: [ :evt | gridShape resetPath ]
 ]

--- a/src/Roassal2/RTStackBarPlot.class.st
+++ b/src/Roassal2/RTStackBarPlot.class.st
@@ -282,7 +282,7 @@ RTStackBarPlot >> renderIn: aView [
 	lines := RTGroup new.
 	values
 		do: [ :tupple | 
-			elements := tupple values asGroup collectWithIndex: [ :aValue :index | self elementOn: aValue -> index ].
+			elements := tupple values asRTGroup collectWithIndex: [ :aValue :index | self elementOn: aValue -> index ].
 			aView addAll: elements.
 			lines add: elements ].
 	lines doWithIndex: [ :l :i | 

--- a/src/Trachel/TRAbstractLineDecoratorShape.class.st
+++ b/src/Trachel/TRAbstractLineDecoratorShape.class.st
@@ -44,9 +44,16 @@ TRAbstractLineDecoratorShape class >> fromLine: aTRLine size: aNumber color: aCo
 	^self from: aTRLine from to: aTRLine to width: aTRLine width size: aNumber color: aColor stroke: aTRLine strokePaint.
 ]
 
-{ #category : #visitor }
+{ #category : #visiting }
 TRAbstractLineDecoratorShape >> accept: aVisitor [
-	aVisitor visitAbstractLineDecorationShape: self
+
+	^ self accept: aVisitor onStart: false
+]
+
+{ #category : #visiting }
+TRAbstractLineDecoratorShape >> accept: aVisitor onStart: aBoolean [
+
+	self subclassResponsibility
 ]
 
 { #category : #accessing }

--- a/src/Trachel/TRArcLineShape.class.st
+++ b/src/Trachel/TRArcLineShape.class.st
@@ -12,6 +12,12 @@ Class {
 	#category : #'Trachel-Shapes'
 }
 
+{ #category : #visiting }
+TRArcLineShape >> accept: aVisitor [
+
+	aVisitor visitArcLine: self
+]
+
 { #category : #accessing }
 TRArcLineShape >> center [
 	^ center

--- a/src/Trachel/TRBezier3Shape.class.st
+++ b/src/Trachel/TRBezier3Shape.class.st
@@ -16,8 +16,8 @@ TRBezier3Shape >> accept: aVisitor [
 ]
 
 { #category : #visitor }
-TRBezier3Shape >> accept: aVisitor with: decoration [
-	aVisitor visitBezierShape: self with: decoration
+TRBezier3Shape >> accept: aVisitor with: anArrayOfDecorationInfo [
+	aVisitor visitBezierShape: self with: anArrayOfDecorationInfo
 ]
 
 { #category : #hooks }

--- a/src/Trachel/TRBezierShape.class.st
+++ b/src/Trachel/TRBezierShape.class.st
@@ -13,8 +13,8 @@ TRBezierShape >> accept: aVisitor [
 ]
 
 { #category : #visitor }
-TRBezierShape >> accept: aVisitor with: decoration [
-	aVisitor visitBezierShape: self with: decoration
+TRBezierShape >> accept: aVisitor with: anArrayOfDecorationInfo [
+	aVisitor visitBezierShape: self with: anArrayOfDecorationInfo
 ]
 
 { #category : #hooks }
@@ -52,6 +52,12 @@ TRBezierShape >> drawOn: athensCanvas [
 { #category : #accessing }
 TRBezierShape >> encompassingRectangle [
 	^ Rectangle encompassing: listOfPoints
+]
+
+{ #category : #accessing }
+TRBezierShape >> from [
+
+	^ self points first
 ]
 
 { #category : #testing }
@@ -104,6 +110,12 @@ TRBezierShape >> position [
 TRBezierShape >> strokePaint: aColor [
 	"set the color of the border line"
 	self color: aColor
+]
+
+{ #category : #accessing }
+TRBezierShape >> to [
+
+	^ self points last
 ]
 
 { #category : #actions }

--- a/src/Trachel/TRCallableObject.class.st
+++ b/src/Trachel/TRCallableObject.class.st
@@ -75,9 +75,10 @@ TRCallableObject >> triggerCallbacksForStep: aStep [
 
 { #category : #callbacks }
 TRCallableObject >> triggerRemoveCallbacks [
+
 	"aStep is a point that represents a translation step"
+
 	self hasCallback ifFalse: [ ^ self ].
-	self callbacks do: [ :c | 
-		c isRemoveCallback ifTrue: [ 
-			c removeShape: self ] ]
+	(Array withAll: self callbacks) do: [ :c | 
+		c isRemoveCallback ifTrue: [ c removeShape: self ] ]
 ]

--- a/src/Trachel/TRCamera.class.st
+++ b/src/Trachel/TRCamera.class.st
@@ -92,7 +92,7 @@ TRCamera >> encompassingRectangle [
 
 { #category : #utility }
 TRCamera >> encompassingRectangleOf: shapes [
-	^ shapes asGroup encompassingRectangle 
+	^ shapes asRTGroup encompassingRectangle 
 
 ]
 

--- a/src/Trachel/TRCanvasGridShape.class.st
+++ b/src/Trachel/TRCanvasGridShape.class.st
@@ -18,6 +18,18 @@ TRCanvasGridShape >> addToOffset: aPoint [
 ]
 
 { #category : #private }
+TRCanvasGridShape >> basicEncompassingRectangle [
+
+	^ (0 @ 0) corner: (0 @ 0)
+]
+
+{ #category : #accessing }
+TRCanvasGridShape >> center [
+
+	^ self canvas camera position
+]
+
+{ #category : #private }
 TRCanvasGridShape >> computePath [
 
 	| width height |
@@ -71,7 +83,7 @@ TRCanvasGridShape >> drawOn: athensCanvas [
 { #category : #accessing }
 TRCanvasGridShape >> encompassingRectangle [
 
-	^ 0 @ 0 corner: 0 @ 0
+	^ self basicEncompassingRectangle
 ]
 
 { #category : #initialization }
@@ -84,9 +96,7 @@ TRCanvasGridShape >> initialize [
 { #category : #asserting }
 TRCanvasGridShape >> shouldBeVisible [
 
-	^ self canvas extent x > spacing and: [ 
-		  self canvas extent y > spacing and: [ 
-			  spacing > (10.0 / (self canvas camera scale max: 0.05)) ] ]
+	^ spacing > (10.0 / (self canvas camera scale max: 0.05))
 ]
 
 { #category : #accessing }

--- a/src/Trachel/TRCanvasGridShape.class.st
+++ b/src/Trachel/TRCanvasGridShape.class.st
@@ -96,7 +96,7 @@ TRCanvasGridShape >> initialize [
 { #category : #asserting }
 TRCanvasGridShape >> shouldBeVisible [
 
-	^ spacing > (10.0 / (self canvas camera scale max: 0.05))
+	^ spacing > (13.0 / (self canvas camera scale max: 0.05))
 ]
 
 { #category : #accessing }

--- a/src/Trachel/TRCanvasGridShape.class.st
+++ b/src/Trachel/TRCanvasGridShape.class.st
@@ -12,6 +12,12 @@ Class {
 	#category : #'Trachel-Shapes'
 }
 
+{ #category : #visiting }
+TRCanvasGridShape >> accept: aVisitor [
+
+	aVisitor visitGrid: self
+]
+
 { #category : #accessing }
 TRCanvasGridShape >> addToOffset: aPoint [
 	offset := offset + aPoint

--- a/src/Trachel/TRCanvasGridShape.class.st
+++ b/src/Trachel/TRCanvasGridShape.class.st
@@ -19,21 +19,23 @@ TRCanvasGridShape >> addToOffset: aPoint [
 
 { #category : #private }
 TRCanvasGridShape >> computePath [
+
 	| width height |
-	width := self canvas extent x / canvas camera scale roundUpTo: spacing.
-	height := self canvas extent y / canvas camera scale roundUpTo: spacing.
-	path := self athensCanvas
-		createPath:
-			[ :builder | 
-			builder absolute.
-			height negated to: height by: spacing do: [ :i | 
-				builder
-					moveTo: width negated @ i;
-					lineTo: width @ i ].
-			width negated to: width by: spacing do: [ :i | 
-				builder
-					moveTo: i @ height negated;
-					lineTo: i @ height ] ]
+	self shouldBeVisible ifFalse: [ ^ self ].
+	width := self canvas extent x / canvas camera scale roundUpTo:
+		         spacing.
+	height := self canvas extent y / canvas camera scale roundUpTo:
+		          spacing.
+	path := self athensCanvas createPath: [ :builder | 
+		        builder absolute.
+		        height negated to: height by: spacing do: [ :i | 
+			        builder
+				        moveTo: width negated @ i;
+				        lineTo: width @ i ].
+		        width negated to: width by: spacing do: [ :i | 
+			        builder
+				        moveTo: i @ height negated;
+				        lineTo: i @ height ] ]
 ]
 
 { #category : #accessing }
@@ -50,25 +52,26 @@ TRCanvasGridShape >> dashes: integers [
 
 { #category : #drawing }
 TRCanvasGridShape >> drawOn: athensCanvas [
+
 	"The shape is first moved by offset, which will always center it on camera, then it is moved by moduled offset, so it will alway move only by at most the modulo"
- 
+
 	| s |
-	athensCanvas pathTransform
-		restoreAfter:
-			[ athensCanvas pathTransform translateBy: offset.
-			athensCanvas pathTransform
-				translateBy: ((offset x % spacing) @ (offset y % spacing)) negated.
-			athensCanvas setShape: self path.
-			s := athensCanvas setStrokePaint: self color.
-			s width: 1.
-			dashes ifNotNil: [ 
-				 s dashes: dashes offset: spacing ].
-			athensCanvas draw ]
+	self shouldBeVisible ifFalse: [ ^ self ].
+	athensCanvas pathTransform restoreAfter: [ 
+		athensCanvas pathTransform translateBy: offset.
+		athensCanvas pathTransform translateBy:
+			(offset x % spacing @ (offset y % spacing)) negated.
+		athensCanvas setShape: self path.
+		s := athensCanvas setStrokePaint: self color.
+		s width: 1.0 / (self canvas camera scale max: 0.05).
+		dashes ifNotNil: [ s dashes: dashes offset: spacing ].
+		athensCanvas draw ]
 ]
 
 { #category : #accessing }
 TRCanvasGridShape >> encompassingRectangle [
-	^ 0 @ 0 corner: 0@0
+
+	^ 0 @ 0 corner: 0 @ 0
 ]
 
 { #category : #initialization }
@@ -76,6 +79,14 @@ TRCanvasGridShape >> initialize [
 	super initialize.
 	color := Color black alpha: 0.05.
 	offset := 0 @ 0
+]
+
+{ #category : #asserting }
+TRCanvasGridShape >> shouldBeVisible [
+
+	^ self canvas extent x > spacing and: [ 
+		  self canvas extent y > spacing and: [ 
+			  spacing > (10.0 / (self canvas camera scale max: 0.05)) ] ]
 ]
 
 { #category : #accessing }

--- a/src/Trachel/TRCircleHeadShape.class.st
+++ b/src/Trachel/TRCircleHeadShape.class.st
@@ -4,6 +4,12 @@ Class {
 	#category : #'Trachel-ShapesForArrow'
 }
 
+{ #category : #visiting }
+TRCircleHeadShape >> accept: aVisitor onStart: aBoolean [
+
+	aVisitor visitCircleHeadShape: self onStart: aBoolean
+]
+
 { #category : #hooks }
 TRCircleHeadShape >> computePath [
 	path := TRPlatform current computeCircleHeadPathFor: self.

--- a/src/Trachel/TRDiamondShape.class.st
+++ b/src/Trachel/TRDiamondShape.class.st
@@ -10,8 +10,8 @@ Class {
 }
 
 { #category : #visitor }
-TRDiamondShape >> accept: aVisitor [
-	aVisitor visitDiamondShape: self
+TRDiamondShape >> accept: aVisitor onStart: aBoolean [
+	aVisitor visitDiamondShape: self onStart: aBoolean
 ]
 
 { #category : #hooks }

--- a/src/Trachel/TREllipseShape.class.st
+++ b/src/Trachel/TREllipseShape.class.st
@@ -26,17 +26,20 @@ TREllipseShape >> defaultStrokeWidth [
 
 { #category : #testing }
 TREllipseShape >> includesPoint: aPoint [
+
 	"Implementation is taken over from EllipseMorph>>containsPoint:"
+
 	| invertedPoint radius other delta xOverY t1 t2 |
+	(self encompassingRectangle containsPoint: aPoint) ifFalse: [ 
+		^ false ].
 	invertedPoint := matrix inverseTransform: aPoint.
-	(rectangle containsPoint: invertedPoint) ifFalse: [ ^ false ]. "quick elimination"
 	radius := rectangle height asFloat / 2.
 	other := rectangle width asFloat / 2.
-	delta := invertedPoint - rectangle topLeft - (other@radius).
+	delta := invertedPoint - rectangle topLeft - (other @ radius).
 	xOverY := rectangle width asFloat / rectangle height asFloat.
 	t1 := (delta x asFloat / xOverY) squared + delta y squared.
 	t2 := radius squared.
-	^ (t1 < t2)  or: [ t1 closeTo: t2 ].
+	^ t1 < t2 or: [ t1 closeTo: t2 ]
 ]
 
 { #category : #initialization }

--- a/src/Trachel/TREmptyArrowHeadShape.class.st
+++ b/src/Trachel/TREmptyArrowHeadShape.class.st
@@ -5,8 +5,8 @@ Class {
 }
 
 { #category : #visitor }
-TREmptyArrowHeadShape >> accept: aVisitor [
-	aVisitor visitArrowHeadShape: self
+TREmptyArrowHeadShape >> accept: aVisitor onStart: aBoolean [
+	aVisitor visitArrowHeadShape: self onStart: aBoolean
 ]
 
 { #category : #hooks }

--- a/src/Trachel/TREmptyNarrowArrowHeadShape.class.st
+++ b/src/Trachel/TREmptyNarrowArrowHeadShape.class.st
@@ -4,6 +4,11 @@ Class {
 	#category : #'Trachel-ShapesForArrow'
 }
 
+{ #category : #visiting }
+TREmptyNarrowArrowHeadShape >> accept: aVisitor onStart: aBoolean [
+	aVisitor visitNarrowArrowHeadShape: self onStart: aBoolean
+]
+
 { #category : #hooks }
 TREmptyNarrowArrowHeadShape >> computePath [
 	| vector r u unit middle endPoint |

--- a/src/Trachel/TRFocusing.class.st
+++ b/src/Trachel/TRFocusing.class.st
@@ -11,7 +11,7 @@ TRFocusing class >> on: canvas [
 
 { #category : #utility }
 TRFocusing >> encompassingRectangleOf: shapes [
-	^ shapes asGroup encompassingRectangle 
+	^ shapes asRTGroup encompassingRectangle 
 
 ]
 

--- a/src/Trachel/TRLabelShape.class.st
+++ b/src/Trachel/TRLabelShape.class.st
@@ -7,7 +7,8 @@ Class {
 		'fontSize',
 		'fontName',
 		'cachedWidth',
-		'cachedHeight'
+		'cachedHeight',
+		'cachedBasicRectangle'
 	],
 	#category : #'Trachel-Shapes'
 }
@@ -65,10 +66,12 @@ TRLabelShape >> ascent [
 
 { #category : #private }
 TRLabelShape >> basicEncompassingRectangle [
+
 	| w h |
-	w := self textWidth.
-	h := self textHeight.
-	^ ((w / -2) @ (h / -2)) extent: (w @ h)
+	^ cachedBasicRectangle ifNil: [ 
+		  w := self textWidth.
+		  h := self textHeight.
+		  cachedBasicRectangle := (w / -2) @ (h / -2) extent: w @ h ]
 ]
 
 { #category : #accessing }
@@ -189,8 +192,10 @@ TRLabelShape >> initialize [
 
 { #category : #initialization }
 TRLabelShape >> resetCache [
+
 	cachedWidth := nil.
-	cachedHeight := nil
+	cachedHeight := nil.
+	cachedBasicRectangle := nil
 ]
 
 { #category : #accessing }
@@ -218,15 +223,24 @@ TRLabelShape >> text: aText on: aPosition [
 
 { #category : #private }
 TRLabelShape >> textHeight [
+
 	"without any transformation"
-	^ cachedHeight ifNil: [ [cachedHeight := font height] on: Error do: [ :ex | cachedHeight := 10 ] ]
+
+	^ cachedHeight ifNil: [ 
+		  [ cachedHeight := font height asFloat ]
+			  on: Error
+			  do: [ :ex | cachedHeight := 10.0 ] ]
 ]
 
 { #category : #private }
 TRLabelShape >> textWidth [
+
 	"without any transformation"
 	"font widthOfString: is a really expensive operation, so we cache it"
-	^ cachedWidth ifNil: [ [ cachedWidth := font widthOfString: text ] on: Error do: [ :ex | cachedWidth := 5 ] ]
+	^ cachedWidth ifNil: [ 
+		  [ cachedWidth := (font widthOfString: text) asFloat ]
+			  on: Error
+			  do: [ :ex | cachedWidth := 5.0 ] ]
 ]
 
 { #category : #public }

--- a/src/Trachel/TRLineShape.class.st
+++ b/src/Trachel/TRLineShape.class.st
@@ -46,8 +46,8 @@ TRLineShape >> accept: aVisitor [
 ]
 
 { #category : #visitor }
-TRLineShape >> accept: aVisitor with: decoration [
-	aVisitor visitLineShape: self with: decoration
+TRLineShape >> accept: aVisitor with: anArrayOfDecorationInfo [
+	aVisitor visitLineShape: self with: anArrayOfDecorationInfo
 ]
 
 { #category : #accessing }

--- a/src/Trachel/TRMorph.class.st
+++ b/src/Trachel/TRMorph.class.st
@@ -480,6 +480,9 @@ TRMorph >> trMouseDragEnd: aMorphicEvent [
 	self announceToEventOverseer: trEvent.
 
 	(shapeBeingPointed isKindOf: TRCanvas) ifFalse: [
+		"first check if shere is a shape under drag 
+		(may not be if events are handled in wrong order during debugging)"
+		shapeUnderDrag ifNil: [ eventBeginingDragging := nil. ^ self ].
 		dropEvent := self eventOfClass: TRMouseDragDrop shape: shapeUnderDrag from: aMorphicEvent.
 		dropEvent draggedShape: shapeBeingPointed.
 		shapeUnderDrag announce: dropEvent.

--- a/src/Trachel/TRMorph.class.st
+++ b/src/Trachel/TRMorph.class.st
@@ -127,9 +127,17 @@ v canvas buildMorph drawOnMockCanvas
 
 { #category : #'event-processed' }
 TRMorph >> eventOfClass: anEventClass actionClass: anActionClass from: aMorphicEvent [
+
 	| relativePosition trEvent shape |
 	relativePosition := self relativePositionFor: aMorphicEvent.
-	shape := self shapeWithAction: anActionClass forPositionInPixels: relativePosition.
+	shape := ((anActionClass = TRMouseDragging or: [ 
+		           anActionClass = TRMouseMove ]) and: [ 
+		          aMorphicEvent yellowButtonPressed ])
+		         ifTrue: [ trachelCanvas ]
+		         ifFalse: [ 
+			         self
+				         shapeWithAction: anActionClass
+				         forPositionInPixels: relativePosition ].
 
 	trEvent := anEventClass fromEvent: aMorphicEvent.
 	trEvent
@@ -195,6 +203,7 @@ TRMorph >> handleKeystroke: anEvent [
 { #category : #'events-processing' }
 TRMorph >> handleMouseMove: anEvent [
 	super handleMouseMove: anEvent.
+	anEvent wasHandled ifTrue: [ ^ self ].
 	self trMouseMove: anEvent
 ]
 
@@ -512,47 +521,74 @@ TRMorph >> trMouseDragStart: aMorphicEvent [
 
 { #category : #'event-processed' }
 TRMorph >> trMouseDragging: aMorphicEvent [
-	| trEvent step underShape trUnderDragEvent overEvent |
+
+	| trEvent step relativePosition |
 	eventBeginingDragging ifNil: [ ^ self ].
 	step := aMorphicEvent position - eventBeginingDragging position.
 
-	trEvent := self eventOfClass: TRMouseDragging from: aMorphicEvent.
+	"manual event creation to avoid shape lookup as we already know it"
+	relativePosition := self relativePositionFor: aMorphicEvent.
+	trEvent := TRMouseDragging fromEvent: aMorphicEvent.
+	trEvent
+		morph: self;
+		canvas: trachelCanvas;
+		shape: shapeBeingPointed;
+		position: relativePosition.
 	trEvent step: step.
 
-	shapeBeingPointed ifNil: [ shapeBeingPointed := trEvent shape ].
 	"If the element was removed during the drag then cancel the event"
-	shapeBeingPointed canvas
-		ifNil: [ eventBeginingDragging := nil.
-			shapeBeingPointed := nil.
-			^ self ].
+	shapeBeingPointed canvas ifNil: [ 
+		eventBeginingDragging := nil.
+		shapeBeingPointed := nil.
+		^ self ].
 
 	trEvent shape: shapeBeingPointed.
 	shapeBeingPointed announce: trEvent.
 	self announceToEventOverseer: trEvent.
 	eventBeginingDragging := aMorphicEvent copy.
-	
-	(shapeBeingPointed isKindOf: TRCanvas) ifTrue: [ ^self ].
-	
-	trUnderDragEvent := self eventOfClass: TRMouseAbstractDrop actionClass: TRMouseAbstractDrop from:  aMorphicEvent under: shapeBeingPointed.
+
+	self trMouseDraggingOver: aMorphicEvent
+]
+
+{ #category : #'private-event-processed' }
+TRMorph >> trMouseDraggingOver: aMorphicEvent [
+
+	| trUnderDragEvent underShape overEvent |
+	(shapeBeingPointed isKindOf: TRCanvas) ifTrue: [ ^ self ].
+
+	trUnderDragEvent := self
+		                    eventOfClass: TRMouseAbstractDrop
+		                    actionClass: TRMouseAbstractDrop
+		                    from: aMorphicEvent
+		                    under: shapeBeingPointed.
 	trUnderDragEvent draggedShape: shapeBeingPointed.
 	underShape := trUnderDragEvent shape.
-	
-	underShape = shapeUnderDrag ifFalse: [ |leaveEvent enterEvent|
-		leaveEvent := self eventOfClass: TRMouseDragLeave shape: shapeUnderDrag from: aMorphicEvent.
+
+	underShape = shapeUnderDrag ifFalse: [ 
+		| leaveEvent enterEvent |
+		leaveEvent := self
+			              eventOfClass: TRMouseDragLeave
+			              shape: shapeUnderDrag
+			              from: aMorphicEvent.
 		leaveEvent draggedShape: shapeBeingPointed.
 		shapeUnderDrag announce: leaveEvent.
 		self announceToEventOverseer: leaveEvent.
-		enterEvent := self eventOfClass: TRMouseDragEnter shape: underShape from: aMorphicEvent.
+		enterEvent := self
+			              eventOfClass: TRMouseDragEnter
+			              shape: underShape
+			              from: aMorphicEvent.
 		enterEvent draggedShape: shapeBeingPointed.
 		underShape announce: enterEvent.
 		self announceToEventOverseer: enterEvent.
-		shapeUnderDrag := underShape.
-	].
-	
-	overEvent := self eventOfClass: TRMouseDragOver shape: shapeUnderDrag from: aMorphicEvent.
+		shapeUnderDrag := underShape ].
+
+	overEvent := self
+		             eventOfClass: TRMouseDragOver
+		             shape: shapeUnderDrag
+		             from: aMorphicEvent.
 	overEvent draggedShape: shapeBeingPointed.
 	shapeUnderDrag announce: overEvent.
-	self announceToEventOverseer: overEvent.
+	self announceToEventOverseer: overEvent
 ]
 
 { #category : #'event-processed' }

--- a/src/Trachel/TRNoDecoratorShape.class.st
+++ b/src/Trachel/TRNoDecoratorShape.class.st
@@ -5,7 +5,8 @@ Class {
 }
 
 { #category : #visitor }
-TRNoDecoratorShape >> accept: aVisitor [
+TRNoDecoratorShape >> accept: aVisitor onStart: aBoolean [
+
 	aVisitor visitNoShape: self
 ]
 

--- a/src/Trachel/TRShape.class.st
+++ b/src/Trachel/TRShape.class.st
@@ -18,7 +18,8 @@ Class {
 
 { #category : #visitor }
 TRShape >> accept: aVisitor [
-	aVisitor visitShape: self
+
+	self subclassResponsibility
 ]
 
 { #category : #actions }

--- a/src/Trachel/TRSimpleArrowShape.class.st
+++ b/src/Trachel/TRSimpleArrowShape.class.st
@@ -5,8 +5,8 @@ Class {
 }
 
 { #category : #visitor }
-TRSimpleArrowShape >> accept: aVisitor [
-	aVisitor visitArrowShape: self
+TRSimpleArrowShape >> accept: aVisitor onStart: aBoolean [
+	aVisitor visitArrowShape: self onStart: aBoolean
 ]
 
 { #category : #hooks }


### PR DESCRIPTION
Multiple fixes and improvements:

- increased efficiency of event handling
- hidden canvas grid when zoomed out too much to be drawn quickly (and too much to be seen well anyway)
- canvas grid now redraws properly when window is resized or camera zoomed out
- graph layout now works with diagrams containing self-edges (direct loops)
- removed some OpenPonk-related code (from classes that originally came from OpenPonk) and updated some comments mentioning OpenPonk
- multiple SVG and JS export fixes, including:
  - support for more shapes, especially line heads
  - if shape does not implement accept:, exception is thrown instead of infinite recursion
  - SVG now handles special characters properly (it does not need escaping of most characters like JS does - it breaks the SVG - same bug still in Roassal3)
  - SVG exporter supports line tails, not just heads - although that made the code a little too complicated :(
- Renamed asGroup to asRTGroup, because there were still issues with using asGroup in images where Roassal3 is present as well (it often created RSGroup where RTGroup should have been and caused errors). asGroup is still present, but deprecated with automatic rewrite.
- fixed errors when some RemoveCallbacks were removed by "chain reactions" while in a loop removing all callbacks (for example, element A depends on element B, we want to remove B, that triggers loop of all RemoveCallbacks of B, one of them is callback from element A that removes itself and therefore removes the RemoveCallback in B and that causes error, because B is still in the loop that triggers all these RemoveCallbacks, including the one now removed)

Most of the efficiency fixes come from @peteruhnak and help a lot in both Pharo 8 and 9, but it is still too slow in Pharo 9 because of the sheer amount of events generated by Pharo