### PR TITLE
Spec2 and Pharo10+ compatibility

### DIFF
--- a/.github/workflows/runTestPharo10.yml
+++ b/.github/workflows/runTestPharo10.yml
@@ -1,0 +1,30 @@
+# This is a basic workflow to help you get started with Actions
+
+name: Test P10
+
+# Controls when the workflow will run
+on:
+  # Triggers the workflow on push or pull request events but only for the master branch
+  push:
+    branches: [ master ]
+  pull_request:
+    branches: [ master ]
+
+  # Allows you to run this workflow manually from the Actions tab
+  workflow_dispatch:
+
+# A workflow run is made up of one or more jobs that can run sequentially or in parallel
+jobs:
+  # This workflow contains a single job called "build"
+  build:
+    # The type of runner that the job will run on
+    runs-on: ubuntu-latest
+
+    # Steps represent a sequence of tasks that will be executed as part of the job
+    steps:
+      # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it
+      - uses: actions/checkout@v2
+
+      # Runs a single command using the runners shell
+      - name: Run unit tests
+        run: bash ./scripts/runTestsOnPharo10.sh

--- a/.smalltalk.ston
+++ b/.smalltalk.ston
@@ -8,9 +8,7 @@ SmalltalkCISpec {
   ],
   
   #testing : {
-  	 #categories : [ 'Roassal2-AttachPoint-Tests', 'Roassal2-Builder-AnimatedScatterPlot', 'Roassal2-Builder-ApplicationMatrix', 'Roassal2-Builder-CircularMap', 'Roassal2-Builder-Common', 'Roassal2-Builder-Composer', 'Roassal2-Builder-DSM', 'Roassal2-Builder-Explora', 'Roassal2-Builder-Grapher-Decorators-Tests', 'Roassal2-Builder-Grapher-Scaling-Tests', 'Roassal2-Builder-Grapher-Tests', 'Roassal2-Builder-Kiviat', 'Roassal2-Builder-Legend', 'Roassal2-Builder-Map-Tests', 'Roassal2-Builder-Mondrian', 'Roassal2-Builder-MondrianOLD', 'Roassal2-Builder-NameCloud', 'Roassal2-Builder-PieChart', 'Roassal2-Builder-ScrollBar', 'Roassal2-Builder-Simon', 'Roassal2-Builder-Spectrograph', 'Roassal2-Builder-StackBarPlot', 'Roassal2-Builder-TextBuilder', 'Roassal2-Builder-Timeline-Tests', 'Roassal2-Builder-TreeMap', 'Roassal2-Builder-UI-Slider', 'Roassal2-Builder-UML',  'Roassal2-ColorNormalizer-Tests', 'Roassal2-Core-Tests', 'Roassal2-Exporter-SVG', 'Roassal2-Interactions', 'Roassal2-Exporter-PNG', 'Roassal2-Exporter-HTML5', 'Roassal2-Interactions-Resize-Tests', 'Roassal2-Layouts-Tests', 
-'Roassal2-LineDecorations', 'Roassal2-MorphSpecific', 'Roassal2-OpenStreetMap', 'Roassal2-Plugins', 'Roassal2-Sparkline', 'Roassal2-Table', 'Roassal2-Tests', 'Roassal2-Utility', 'Trachel-MorphSpecific', 'Trachel-Tests', 'Trachel-Viva', 'Roassal2GT-Glamour', 'Roassal2GT-Glamour-Actions', 'Roassal2GT-Glamour-Context', 'Roassal2GT-Glamour-Roassal-Interaction', 'Roassal2GT-Tests-Examples'
- ],
+  	 #categories : [ 'Roassal2*', 'Trachel*' ],
   	 #defaultTimeout : 120
    	}
 }

--- a/.smalltalk_stable.ston
+++ b/.smalltalk_stable.ston
@@ -10,8 +10,6 @@ SmalltalkCISpec {
   ],
   
   #testing : {
-  	 #categories : [ 'Roassal2-AttachPoint-Tests', 'Roassal2-Builder-AnimatedScatterPlot', 'Roassal2-Builder-ApplicationMatrix', 'Roassal2-Builder-CircularMap', 'Roassal2-Builder-Common', 'Roassal2-Builder-Composer', 'Roassal2-Builder-DSM', 'Roassal2-Builder-Explora', 'Roassal2-Builder-Grapher-Decorators-Tests', 'Roassal2-Builder-Grapher-Scaling-Tests', 'Roassal2-Builder-Grapher-Tests', 'Roassal2-Builder-Kiviat', 'Roassal2-Builder-Legend', 'Roassal2-Builder-Map-Tests', 'Roassal2-Builder-Mondrian', 'Roassal2-Builder-MondrianOLD', 'Roassal2-Builder-NameCloud', 'Roassal2-Builder-PieChart', 'Roassal2-Builder-ScrollBar', 'Roassal2-Builder-Simon', 'Roassal2-Builder-Spectrograph', 'Roassal2-Builder-StackBarPlot', 'Roassal2-Builder-TextBuilder', 'Roassal2-Builder-Timeline-Tests', 'Roassal2-Builder-TreeMap', 'Roassal2-Builder-UI-Slider', 'Roassal2-Builder-UML',  'Roassal2-ColorNormalizer-Tests', 'Roassal2-Core-Tests', 'Roassal2-Exporter-SVG', 'Roassal2-Interactions', 'Roassal2-Exporter-PNG', 'Roassal2-Exporter-HTML5', 'Roassal2-Interactions-Resize-Tests', 'Roassal2-Layouts-Tests', 
-'Roassal2-LineDecorations', 'Roassal2-MorphSpecific', 'Roassal2-OpenStreetMap', 'Roassal2-Plugins', 'Roassal2-Sparkline', 'Roassal2-Table', 'Roassal2-Tests', 'Roassal2-Utility', 'Trachel-MorphSpecific', 'Trachel-Tests', 'Trachel-Viva', 'Roassal2GT-Glamour', 'Roassal2GT-Glamour-Actions', 'Roassal2GT-Glamour-Context', 'Roassal2GT-Glamour-Roassal-Interaction', 'Roassal2GT-Tests-Examples'
- ]
+  	 #categories : [ 'Roassal2*', 'Trachel*' ]
    	}
 }

--- a/scripts/runTestsOnPharo10.sh
+++ b/scripts/runTestsOnPharo10.sh
@@ -1,0 +1,19 @@
+curl -L https://get.pharo.org/64/100+vm | bash
+./pharo --headless Pharo.image ./scripts/runTests.st
+
+FILE=/tmp/result.txt
+if [ ! -f "$FILE" ]; then
+    echo "ERROR: $FILE does not exists!"
+    exit 1
+fi
+
+
+cat $FILE
+
+if grep -q ERROR "$FILE"; then
+		echo "SOME ERRORS!"
+		exit 1
+else
+		echo "ALL TEST PASSED"
+		exit 0
+fi

--- a/src/BaselineOfRoassal2/BaselineOfRoassal2.class.st
+++ b/src/BaselineOfRoassal2/BaselineOfRoassal2.class.st
@@ -44,9 +44,15 @@ BaselineOfRoassal2 >> baseline: spec [
 				package: 'Roassal2-OpenStreetMap' with: [ spec requires: #('Roassal2') ];
 				package: 'Roassal2-ExporterVW' with: [ spec requires: #('Roassal2') ] ]. 
 
-			spec for: #(#'pharo10.x' #'pharo11.x' #'pharo12.x') do: [spec group: 'Roassal2SpecGroup' with: #(Roassal2Spec2) ].
-			spec for: #(#'pharo9.x') do: [spec group: 'Roassal2SpecGroup' with: #(Roassal2Spec Roassal2Spec2) ].
-			spec for: #(#'pharo6.x' #'pharo7.x' #'pharo8.x') do: [spec group: 'Roassal2SpecGroup' with: #(Roassal2Spec) ].
+			spec for: #(#'pharo10.x' #'pharo11.x' #'pharo12.x') do: [
+				spec group: 'Roassal2SpecGroup' with: #(Roassal2Spec2)
+			].
+			spec for: #(#'pharo9.x') do: [
+				spec group: 'Roassal2SpecGroup' with: #(Roassal2Spec Roassal2Spec2)
+			].
+			spec for: #(#'pharo8.x' #'pharo7.x') do: [
+				spec group: 'Roassal2SpecGroup' with: #(Roassal2Spec).
+			].	
 
 			spec group: 'Core' with: #(
 				'Trachel' 
@@ -63,8 +69,16 @@ BaselineOfRoassal2 >> baseline: spec [
 				'Roassal2-AnimatedScatterPlot'
 				'Roassal2-UML'
 				'Roassal2-Benchmarks').
-			spec group: 'Minimal' with: #('Core' 'Roassal2GT').
 			spec group: 'NoGlamour' with: #('Core' 'Roassal2-Tests' 'Roassal2-Exporter-Tests').
-			spec group: 'Tests' with: #('Minimal' 'Roassal2-Tests' 'Roassal2-Exporter-Tests' 'Roassal2GT-Tests').
+			
+			spec for: #(#'pharo9.x' #'pharo8.x' #'pharo7.x') do: [
+				spec group: 'Minimal' with: #('Core' 'Roassal2GT').
+				spec group: 'Tests' with: #('Minimal' 'Roassal2-Tests' 'Roassal2-Exporter-Tests' 'Roassal2GT-Tests').
+			].			
+			spec for: #(#'pharo10.x' #'pharo11.x' #'pharo12.x') do: [
+				spec group: 'Minimal' with: #('Core').
+				spec group: 'Tests' with: #('NoGlamour').
+			].
+			
 			spec group: 'default' with: #('Tests' 'Roassal2-OpenStreetMap' 'Roassal2-ExporterVW').
 ]

--- a/src/BaselineOfRoassal2/BaselineOfRoassal2.class.st
+++ b/src/BaselineOfRoassal2/BaselineOfRoassal2.class.st
@@ -25,6 +25,7 @@ BaselineOfRoassal2 >> baseline: spec [
 				package: 'Roassal2-Core' with: [ spec requires: #('Trachel' 'Athens-SVG-PathConverter' 'Geometry') ];
 				package: 'Roassal2' with: [ spec requires: #('Roassal2-Core') ];
 				package: 'Roassal2Spec' with: [ spec requires: #('Roassal2') ];
+				package: 'Roassal2Spec2' with: [ spec requires: #('Roassal2') ];
 				package: 'Roassal2-Exporter' with: [ spec requires: #('Trachel' 'Roassal2') ];
 				package: 'Roassal2-Exporter-Tests' with: [ spec requires: #('Roassal2-Exporter' 'Roassal2-Tests') ];
 				package: 'Roassal2GT' with: [ spec requires: #('Roassal2' 'GToolkitExamples' 'Roassal2-Exporter') ];
@@ -43,11 +44,15 @@ BaselineOfRoassal2 >> baseline: spec [
 				package: 'Roassal2-OpenStreetMap' with: [ spec requires: #('Roassal2') ];
 				package: 'Roassal2-ExporterVW' with: [ spec requires: #('Roassal2') ] ]. 
 
+			spec for: #(#'pharo10.x' #'pharo11.x' #'pharo12.x') do: [spec group: 'Roassal2SpecGroup' with: #(Roassal2Spec2) ].
+			spec for: #(#'pharo9.x') do: [spec group: 'Roassal2SpecGroup' with: #(Roassal2Spec Roassal2Spec2) ].
+			spec for: #(#'pharo6.x' #'pharo7.x' #'pharo8.x') do: [spec group: 'Roassal2SpecGroup' with: #(Roassal2Spec) ].
+
 			spec group: 'Core' with: #(
 				'Trachel' 
 				'Roassal2-Core'
 				'Roassal2'
-				'Roassal2Spec'
+				'Roassal2SpecGroup'
 				'Roassal2-Exporter'
 				'Roassal2-Rules'
 				'Roassal2-Calendar'

--- a/src/Roassal2/RTExampleBrowser.class.st
+++ b/src/Roassal2/RTExampleBrowser.class.st
@@ -10,17 +10,20 @@ Class {
 
 { #category : #menu }
 RTExampleBrowser class >> menuCommandOn: aBuilder [
+
 	<worldMenu>
-	((aBuilder item: #Roassal) icon: RTIcon smallRoassal)
-	withSeparatorAfter;
-	with: [
-		(aBuilder item: #'Roassal Examples')
-			order: 0.1; 
-			parent: #Roassal;
-			label: 'Roassal examples';
-			help: 'Browse Roassal interactive examples';
-			icon: RTIcon smallRoassal;
-			action: [ self new open ] ]
+	((aBuilder item: #Roassal)
+		 order: 142;
+		 icon: RTIcon smallRoassal)
+		withSeparatorAfter;
+		with: [ 
+			(aBuilder item: #'Roassal Examples')
+				order: 0.1;
+				parent: #Roassal;
+				label: 'Roassal examples';
+				help: 'Browse Roassal interactive examples';
+				icon: RTIcon smallRoassal;
+				action: [ self new open ] ]
 ]
 
 { #category : #'instance creation' }

--- a/src/Roassal2Spec2/SpAbstractMorphicAdapter.extension.st
+++ b/src/Roassal2Spec2/SpAbstractMorphicAdapter.extension.st
@@ -1,0 +1,7 @@
+Extension { #name : #SpAbstractMorphicAdapter }
+
+{ #category : #'*Roassal2Spec2' }
+SpAbstractMorphicAdapter >> basicAdapt: aPresenter [
+
+	super adapt: aPresenter
+]

--- a/src/Roassal2Spec2/SpMorphicRoassal2Adapter.class.st
+++ b/src/Roassal2Spec2/SpMorphicRoassal2Adapter.class.st
@@ -1,0 +1,71 @@
+Class {
+	#name : #SpMorphicRoassal2Adapter,
+	#superclass : #SpAbstractMorphicAdapter,
+	#instVars : [
+		'view',
+		'canvas'
+	],
+	#category : #'Roassal2Spec2-Core'
+}
+
+{ #category : #initialization }
+SpMorphicRoassal2Adapter >> adapt: aComposableModel [
+
+	self basicAdapt: aComposableModel.
+
+	view := widget.
+	canvas := view setUpCanvas.
+	widget := canvas buildMorph.
+
+	self addSettingsTo: self widget.
+	self addKeyBindingsTo: self widget.
+	self addEventsTo: self widget.
+
+	widget
+		setProperty: #model toValue: self;
+		hResizing: #spaceFill;
+		vResizing: #spaceFill.
+
+	self basicApplyScript
+]
+
+{ #category : #'scripting actions' }
+SpMorphicRoassal2Adapter >> applyScript [
+	| extent |
+	extent := canvas extent.
+	self freeCanvas.
+	self basicApplyScript.
+	canvas extent: extent.
+	
+]
+
+{ #category : #'scripting actions' }
+SpMorphicRoassal2Adapter >> basicApplyScript [
+
+	self model script cull: view cull: canvas.
+
+	self widgetDo: #startStepping.
+	view when: TRMouseEnter do: [ widget takeKeyboardFocus ]
+]
+
+{ #category : #factory }
+SpMorphicRoassal2Adapter >> buildWidget [
+
+	^ RTView new
+]
+
+{ #category : #'scripting actions' }
+SpMorphicRoassal2Adapter >> freeCanvas [
+	view := self buildWidget.
+	canvas := view setUpCanvas.
+
+	widget canvas: canvas.
+	canvas morph: widget.
+	widget extent: canvas extent
+]
+
+{ #category : #accessing }
+SpMorphicRoassal2Adapter >> view [
+
+	^ view
+]

--- a/src/Roassal2Spec2/SpRoassal2Presenter.class.st
+++ b/src/Roassal2Spec2/SpRoassal2Presenter.class.st
@@ -1,0 +1,50 @@
+Class {
+	#name : #SpRoassal2Presenter,
+	#superclass : #SpAbstractWidgetPresenter,
+	#instVars : [
+		'script'
+	],
+	#category : #'Roassal2Spec2-Core'
+}
+
+{ #category : #specs }
+SpRoassal2Presenter class >> adapterName [
+	^ #SpMorphicRoassal2Adapter
+]
+
+{ #category : #'instance creation' }
+SpRoassal2Presenter class >> open [
+	<script>
+	^ self new openWithSpec
+]
+
+{ #category : #initialization }
+SpRoassal2Presenter >> initialize [
+	super initialize.
+	script := [ :v | ] asValueHolder.
+	script whenChangedDo: [ :s | self refresh ].
+]
+
+{ #category : #refreshing }
+SpRoassal2Presenter >> refresh [ 
+	self changed: #applyScript with: #()
+]
+
+{ #category : #initialization }
+SpRoassal2Presenter >> release [
+	self class instVarNames do: [ :n | self instVarNamed: n put: nil ]
+]
+
+{ #category : #accessing }
+SpRoassal2Presenter >> script [
+	^ script value
+]
+
+{ #category : #accessing }
+SpRoassal2Presenter >> script: anObject [
+
+	"Set the block that draws the visualization.
+	 It should take two arguments: the view and the canvas"
+
+	script value: anObject
+]

--- a/src/Roassal2Spec2/TREvent.extension.st
+++ b/src/Roassal2Spec2/TREvent.extension.st
@@ -1,0 +1,7 @@
+Extension { #name : #TREvent }
+
+{ #category : #'*Roassal2Spec2' }
+TREvent >> isMouse [
+
+	^ false
+]

--- a/src/Roassal2Spec2/TRMouseClick.extension.st
+++ b/src/Roassal2Spec2/TRMouseClick.extension.st
@@ -1,0 +1,7 @@
+Extension { #name : #TRMouseClick }
+
+{ #category : #'*Roassal2Spec2' }
+TRMouseClick >> isMouse [
+
+	^ true
+]

--- a/src/Roassal2Spec2/package.st
+++ b/src/Roassal2Spec2/package.st
@@ -1,0 +1,1 @@
+Package { #name : #Roassal2Spec2 }

--- a/src/Trachel/TRPharoPlatform.class.st
+++ b/src/Trachel/TRPharoPlatform.class.st
@@ -302,7 +302,8 @@ TRPharoPlatform >> fontFamilyName: name size: number [
 
 { #category : #public }
 TRPharoPlatform >> fontListStrings [
-	^ FontChooser new fontListStrings.
+
+	^ LogicalFontManager current allFamilies collect: #familyName
 ]
 
 { #category : #'accessing-classes' }


### PR DESCRIPTION
The gratest change is creation of Roassal2Spec2 package that allows using Roassal2 with Spec2.

In Pharo 10+, only this Roassal2Spec2 is loaded (Roassal2Spec is not, Spec1 does not exist there so it is not even loadable)
In Pharo 9, both original Roassal2Spec and Roassal2Spec2 is loaded (and usable).
In Pharo 8-, Spec2 is too outdated so only original Roassal2Spec is loaded.

There are also few minor changes to accomodate differences in Pharo10+, like way of getting available fonts or fixing order of world menu items.

After these changes, Roassal 2 is usable with both Spec1 (in Pharo 8 and 9) and Spec2 (in Pharo 10 and 11). I did not test Pharo 7- as it is already recommended to use older fixed branch.

Current builds of OpenPonk use Spec2, are build on Pharo 10 and use this Roassal2 commit for that.